### PR TITLE
Hide edit profile button

### DIFF
--- a/inertia/pages/dashboard/show.tsx
+++ b/inertia/pages/dashboard/show.tsx
@@ -48,7 +48,7 @@ export default function Dashboard({
               </dl>
             </div>
           </div>
-          <div className="self-center">
+          <div className="self-center hidden">
             <Button href="#" outline>
               Edit Profile
             </Button>


### PR DESCRIPTION
Temporary change until we implement something for it. Linking just to the bluesky profile page probably wouldn't have made any sense to people using the portal.