### PR TITLE
Fix mobile friendliness of layout

### DIFF
--- a/inertia/components/DashboardNavbar.tsx
+++ b/inertia/components/DashboardNavbar.tsx
@@ -5,33 +5,29 @@ import { Form } from '@adonisjs/inertia/react'
 import { Button } from '~/lib/button'
 import { Text } from '~/lib/text'
 import { useAuth } from '~/utils/use_auth'
-import { Dropdown, DropdownButton, DropdownMenu } from '~/lib/dropdown'
 import { ThemeToggle } from './ThemeToggle'
 import { UserAvatar } from './UserAvatar'
 
-export default function DashboardNavbar() {
+export default function DashboardNavbar({ className }: React.ComponentProps<'div'>) {
   const user = useAuth()
 
   return (
-    <Navbar className="px-4">
+    <Navbar className={className}>
       <Link route="home" aria-label="Home" className="rounded-sm">
         <Logo />
       </Link>
       <NavbarSpacer />
       <NavbarSection>
-        <Dropdown>
-          <DropdownButton as={NavbarItem} aria-label="Account menu">
-            <Text>@{user.handle}</Text>
-            <UserAvatar user={user} />
-          </DropdownButton>
-          <DropdownMenu className="min-w-40" anchor="bottom end">
-            <Form route="oauth.logout" className="col-span-full min-w-40 flex justify-stretch">
-              <Button type="submit" plain className="grow text-left">
-                Logout
-              </Button>
-            </Form>
-          </DropdownMenu>
-        </Dropdown>
+        <NavbarItem className="hidden md:flex pointer-events-none" as={'div'}>
+          <UserAvatar user={user} />
+          <Text>@{user.handle}</Text>
+        </NavbarItem>
+
+        <Form route="oauth.logout" className="justify-stretch hidden lg:flex">
+          <Button type="submit" outline>
+            Logout
+          </Button>
+        </Form>
         <ThemeToggle />
       </NavbarSection>
     </Navbar>

--- a/inertia/components/Hero.tsx
+++ b/inertia/components/Hero.tsx
@@ -4,17 +4,23 @@ import { LockClosedIcon } from '@heroicons/react/24/solid'
 
 export function Hero() {
   return (
-    <Container className="pt-10 pb-16 text-center lg:pt-24">
-      <div className="py-1 px-4 mb-6 inline-block rounded-xl bg-amber-100 border-amber-300 border text-yellow-600 uppercase font-bold whitespace-nowrap">
-        Now open &middot; Join the future of the web
+    <Container className="pt-6 md:pt-10 pb-16 text-center lg:pt-24">
+      <div className="py-1 px-4 mb-8 md:mb-6 md:inline-block rounded-xl bg-amber-100 border-amber-300 border text-yellow-600 uppercase font-bold">
+        <span className="flex flex-col md:flex-row gap-x-2 justify-center-safe">
+          <span>
+            Now open<span className="inline md:hidden">!</span>
+          </span>
+          <span className="hidden md:inline">&middot;</span>
+          <span>Join the future of the web</span>
+        </span>
       </div>
-      <h1 className="mx-auto max-w-4xl font-display text-5xl leading-[1.3] font-extrabold tracking-tight text-slate-900 dark:text-slate-200 sm:text-7xl">
+      <h1 className="mx-auto max-w-4xl font-display text-3xl sm:text-6xl lg:text-5xl leading-[1.3] font-extrabold tracking-tight text-slate-900 dark:text-slate-200">
         Eurosky: Your Portal to <div className="text-amber-400">the Atmosphere.</div>
       </h1>
       <p className="mx-auto mt-6 max-w-2xl text-lg text-gray-500 dark:text-gray-400 font-bold">
         One account. Dozens of apps. No lock-in.
       </p>
-      <div className="mt-6 flex justify-center gap-x-6 text-2xl">
+      <div className="mt-6 flex justify-center gap-4 md:gap-6 text-2xl flex-col md:flex-row">
         <Button route="account.create" className="py-3! px-6!" color="amber">
           Create your account →
         </Button>

--- a/inertia/components/PublicNavbar.tsx
+++ b/inertia/components/PublicNavbar.tsx
@@ -8,10 +8,9 @@ import { urlFor } from '~/client'
 
 export default function PublicNavbar() {
   const page = usePage()
-  console.log(page.url)
 
   return (
-    <Navbar className="ps-4 pe-8">
+    <Navbar className="gap-2! md:gap-4! pe-6">
       <Link route="home" aria-label="Home">
         <Logo />
       </Link>
@@ -30,10 +29,10 @@ export default function PublicNavbar() {
         >
           Privacy
         </NavbarItem>
-        <Button route="auth.login" outline className="hidden md:visible">
+        <Button route="auth.login" outline className="hidden! md:inline-flex!">
           Sign in
         </Button>
-        <ThemeToggle />
+        <ThemeToggle className="hidden! md:inline-flex!" />
       </NavbarSection>
     </Navbar>
   )

--- a/inertia/components/ThemeToggle.tsx
+++ b/inertia/components/ThemeToggle.tsx
@@ -3,8 +3,9 @@ import * as ThemeUtils from '~/utils/darkmode'
 import { type Theme } from '~/utils/darkmode'
 import { LightBulbIcon, MoonIcon } from '@heroicons/react/24/solid'
 import { Button } from '~/lib/button'
+import clsx from 'clsx'
 
-export function ThemeToggle({}: React.ComponentPropsWithoutRef<'div'>) {
+export function ThemeToggle({ className }: React.ComponentPropsWithoutRef<'div'>) {
   const [theme, setTheme] = useState<Theme>(ThemeUtils.getTheme())
 
   useEffect(() => {
@@ -26,7 +27,11 @@ export function ThemeToggle({}: React.ComponentPropsWithoutRef<'div'>) {
   }, [theme])
 
   return (
-    <Button className="relative inline-block w-10 h-10 p-0.5!" plain onClick={toggleTheme}>
+    <Button
+      className={clsx(className, 'relative inline-block w-10 h-10 p-0.5!')}
+      plain
+      onClick={toggleTheme}
+    >
       {theme === 'dark' ? (
         <LightBulbIcon title="Set theme to light" />
       ) : (

--- a/inertia/components/layouts/authenticated.tsx
+++ b/inertia/components/layouts/authenticated.tsx
@@ -6,6 +6,7 @@ import DashboardNavbar from '~/components/DashboardNavbar'
 import {
   Sidebar,
   SidebarBody,
+  SidebarFooter,
   SidebarHeading,
   SidebarItem,
   SidebarLabel,
@@ -22,12 +23,17 @@ import {
   LifebuoyIcon,
   LockClosedIcon,
 } from '@heroicons/react/24/solid'
+import { UserAvatar } from '../UserAvatar'
+import { useAuth } from '~/utils/use_auth'
+import { Form } from '@adonisjs/inertia/react'
+import { Button } from '~/lib/button'
 
 export function AuthenticatedLayout(props: { children: ReactElement<Data.SharedProps> }) {
   const {
     props: { authorizationServer },
     url,
   } = usePage()
+  const user = useAuth()
 
   const manageUrl = useMemo(() => {
     return new URL('/account', authorizationServer).toString()
@@ -35,9 +41,11 @@ export function AuthenticatedLayout(props: { children: ReactElement<Data.SharedP
 
   return (
     <div>
-      <DashboardNavbar />
+      <div className="hidden lg:block lg:pe-4">
+        <DashboardNavbar />
+      </div>
       <SidebarLayout
-        navbar={<div />}
+        navbar={<DashboardNavbar />}
         sidebar={
           <Sidebar>
             <SidebarBody>
@@ -79,6 +87,21 @@ export function AuthenticatedLayout(props: { children: ReactElement<Data.SharedP
                 </SidebarItem>
               </SidebarSection>
             </SidebarBody>
+            <SidebarFooter className="lg:hidden">
+              <SidebarSection>
+                <SidebarItem as={'div'} className="pointer-events-none">
+                  <UserAvatar user={user} />
+                  <SidebarLabel>@{user.handle}</SidebarLabel>
+                </SidebarItem>
+                <SidebarItem>
+                  <Form route="oauth.logout" className="w-full flex justify-stretch">
+                    <Button type="submit" className="w-full text-left">
+                      Logout
+                    </Button>
+                  </Form>
+                </SidebarItem>
+              </SidebarSection>
+            </SidebarFooter>
           </Sidebar>
         }
         children={

--- a/inertia/css/app.css
+++ b/inertia/css/app.css
@@ -1,6 +1,10 @@
 @import 'tailwindcss';
 @custom-variant dark (&:where(.dark, .dark *));
 
+@theme {
+  --text-tiny: 0.625rem;
+}
+
 @utility min-h-dvh-minus-* {
   min-height: calc(100dvh - var(--spacing) * --value(integer));
   min-height: calc(100dvh - --value([length]));

--- a/inertia/layouts/default.tsx
+++ b/inertia/layouts/default.tsx
@@ -32,7 +32,7 @@ export default function Layout({ children }: { children: ReactElement<Data.Share
   return (
     <div>
       {children.props.isAuthenticated ? <DashboardNavbar /> : <PublicNavbar />}
-      <main>{children}</main>
+      <main className="mb-2">{children}</main>
       <Toaster position="top-center" richColors />
     </div>
   )

--- a/inertia/lib/navbar.tsx
+++ b/inertia/lib/navbar.tsx
@@ -9,7 +9,7 @@ import { Link } from './link'
 import type { LinkProps } from '@adonisjs/inertia/react'
 
 export function Navbar({ className, ...props }: React.ComponentPropsWithoutRef<'nav'>) {
-  return <nav {...props} className={clsx(className, 'flex flex-1 items-center gap-4 py-2.5')} />
+  return <nav {...props} className={clsx(className, 'flex flex-1 items-center gap-4 md:py-2.5')} />
 }
 
 export function NavbarDivider({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) {

--- a/inertia/lib/sidebar-layout.tsx
+++ b/inertia/lib/sidebar-layout.tsx
@@ -36,7 +36,7 @@ function MobileSidebar({
         className="fixed inset-y-0 w-full max-w-80 p-2 transition duration-300 ease-in-out data-closed:-translate-x-full"
       >
         <div className="flex h-full flex-col rounded-lg bg-white shadow-xs ring-1 ring-slate-950/5 dark:bg-slate-900 dark:ring-white/10">
-          <div className="-mb-3 px-4 pt-3">
+          <div className="-mb-3 px-4 pt-3 self-end">
             <Headless.CloseButton as={NavbarItem} aria-label="Close navigation">
               <CloseMenuIcon />
             </Headless.CloseButton>
@@ -67,12 +67,12 @@ export function SidebarLayout({
 
       {/* Navbar on mobile */}
       <header className="flex items-center px-4 lg:hidden">
+        <div className="min-w-0 flex-1">{navbar}</div>
         <div className="py-2.5">
           <NavbarItem onClick={() => setShowSidebar(true)} aria-label="Open navigation">
             <OpenMenuIcon />
           </NavbarItem>
         </div>
-        <div className="min-w-0 flex-1">{navbar}</div>
       </header>
 
       {/* Content */}

--- a/inertia/pages/create-account.tsx
+++ b/inertia/pages/create-account.tsx
@@ -11,7 +11,7 @@ export default function CreateAccount(
 ) {
   return (
     <Container>
-      <Card className="my-10 w-1/2 m-auto p-4">
+      <Card className="my-10 w-full md:w-3/4 lg:w-1/2 m-auto p-4">
         <h1 className="mx-auto max-w-4xl mb-2 text-center font-display text-3xl leading-[1.2] font-extrabold tracking-tight text-slate-900 dark:text-slate-200 sm:text-5xl">
           Create Your <div className="text-amber-400">Eurosky Account.</div>
         </h1>

--- a/inertia/pages/dashboard/show.tsx
+++ b/inertia/pages/dashboard/show.tsx
@@ -23,16 +23,16 @@ export default function Dashboard({
   }
   return (
     <>
-      <Card className="p-4">
+      <Card className="p-3 md:p-4">
         <div className="flex flex-row justify-between">
           <div className="flex flex-row gap-6">
-            <div className="size-20 self-center">
+            <div className="size-14 md:size-20 md:self-center">
               <UserAvatar user={user} />
             </div>
             <div className="flex flex-col">
               <Heading level={2}>{user.displayName ?? user.handle}</Heading>
               <Text className="text-slate-400!">@{user.handle}</Text>
-              <dl className="grid grid-cols-1 sm:grid-cols-3">
+              <dl className="hidden md:grid grid-cols-1 sm:grid-cols-3">
                 <div className="pr-4 py-2 sm:col-span-1 flex flex-col-reverse">
                   <StatHeading>Posts</StatHeading>
                   <StatValue>{user.postsCount ?? 0}</StatValue>
@@ -62,7 +62,7 @@ export default function Dashboard({
               heading="Welcome to the Atmosphere"
               highlight={true}
               action={
-                <Button onClick={hideIntro} outline>
+                <Button onClick={hideIntro} outline className="w-full md:w-auto">
                   Dismiss
                 </Button>
               }
@@ -72,7 +72,8 @@ export default function Dashboard({
             </ActionItem>
             <ActionItem heading="Your account is ready">
               <span className="white-space-collapse">
-                You've joined the Atmosphere with Euroesky. Your handle is{' '}
+                You've joined the Atmosphere with Eurosky.
+                <span className="block visible md:hidden pb-2"></span> Your handle is{' '}
                 <strong className="text-amber-500 font-bold whitespace-pre">@{user.handle}</strong>
                 {'. '}
                 Don't forget to verify your email.
@@ -152,7 +153,7 @@ function ActionItem({
       className={clsx(
         className,
         highlight ? 'bg-amber-100 dark:bg-slate-400/50' : '',
-        'flex items-center justify-between gap-x-6 py-3 px-4'
+        'flex flex-col md:flex-row items-center justify-between gap-x-6 gap-y-4 py-3 px-4'
       )}
     >
       <div className="flex flex-col grow">
@@ -166,7 +167,7 @@ function ActionItem({
         </div>
         <div
           className={clsx(
-            'mt-0.5 flex flex-row justify-between text-xs/5',
+            'mt-0.5 flex flex-row justify-between text-xs/6',
             highlight ? 'text-gray-500 dark:text-gray-300' : 'text-gray-500 dark:text-gray-400'
           )}
         >

--- a/inertia/pages/home.tsx
+++ b/inertia/pages/home.tsx
@@ -16,7 +16,7 @@ export default function Home({
   return (
     <>
       <Hero />
-      <Container id="apps">
+      <Container id="apps" className="py-4">
         <h2 className="text-lg text-gray-400 dark:text-gray-400 font-bold uppercase text-center">
           An app for everything
         </h2>

--- a/inertia/pages/legal/show.tsx
+++ b/inertia/pages/legal/show.tsx
@@ -5,7 +5,7 @@ import { InertiaProps } from '~/types'
 export default function Legal(props: InertiaProps<{ document: string }>) {
   return (
     <Container>
-      <Card className="my-10 w-3/4 m-auto p-4">
+      <Card className="my-10 w-full md:w-3/4 m-auto p-4">
         <div
           className="legal-document p-4 dark:text-slate-200 text-gray-800"
           dangerouslySetInnerHTML={{ __html: props.document }}

--- a/inertia/pages/login.tsx
+++ b/inertia/pages/login.tsx
@@ -10,7 +10,7 @@ import Card from '~/lib/card'
 export default function Login() {
   return (
     <Container>
-      <Card className="mt-10 w-1/2 m-auto p-4">
+      <Card className="mt-10 w-full md:w-3/4 lg:w-1/2 m-auto p-4">
         <h1 className="mx-auto max-w-4xl mb-2 text-center font-display text-3xl leading-[1.2] font-extrabold tracking-tight text-slate-900 dark:text-slate-200 sm:text-5xl">
           Sign Into Your <div className="text-amber-400">Eurosky Account.</div>
         </h1>

--- a/inertia/pages/onboarding.tsx
+++ b/inertia/pages/onboarding.tsx
@@ -11,7 +11,7 @@ export default function Onboarding(
 ) {
   return (
     <Container>
-      <Card className="mt-10 w-1/2 m-auto p-4 mb-6">
+      <Card className="mt-10 w-full md:w-1/2 m-auto p-4 mb-6">
         <h1 className="mx-auto max-w-4xl mb-2 text-center font-display text-3xl leading-[1.2] font-extrabold tracking-tight text-slate-900 dark:text-slate-200 sm:text-5xl">
           Welcome to <div className="text-amber-400">Eurosky.</div>
         </h1>


### PR DESCRIPTION
Fixes for #29 

## Mobile Homepage:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/45f30e7b-d491-465a-b5c0-92285ba5d09a" />

### Mobile Sign up:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/3c8256ef-ab0c-4c79-8711-42d832786667" />


### Mobile Sign in:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/d0bea50a-a6ba-4c8e-8250-53454244441e" />


## Homepage small tablet:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/cdef57bc-ad02-48b5-95f6-2f7bc19ce65b" />

### Small Tablet Login:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/0da17fab-9dee-4789-ba08-7cdef229a947" />

### Large Tablet Login:
<img width="700" alt="image" src="https://github.com/user-attachments/assets/2d3cad59-26b6-419d-a4ce-be9c4a5d66e8" />


## Homepage desktop:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/4fcb5c8f-baa9-4a7f-b202-3965e1753abb" />


## Authenticated mobile layout:

<img width="400" alt="mobile layout without menu open" src="https://github.com/user-attachments/assets/33d1a785-1064-49a7-8583-f41c534c2813" /> 
<img width="400" alt="image" src="https://github.com/user-attachments/assets/f420446f-3bd8-4c9f-8322-9c03ef069f6b" />

## Authenticated tablet layout:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/3f634ca7-95e4-45a7-83f6-126dd3d96d6e" />
<img width="600" alt="image" src="https://github.com/user-attachments/assets/0f5be85d-3eaf-4d76-9928-4aecf576741a" />

## Authenticated desktop layout:
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/11b0aba9-7109-4f82-9552-7c03d42468fc" />
