### PR TITLE
Add iOS and Android platforms to Popfeed entry

### DIFF
--- a/data/apps.json
+++ b/data/apps.json
@@ -98,7 +98,7 @@
     "name": "Popfeed",
     "summary": "Discover films, TV, games, books and music",
     "url": "https://popfeed.social/find",
-    "platforms": ["web"],
+    "platforms": ["web", "ios", "android"],
     "category": "explore-more",
     "icon": {
       "path": "./icons/popfeed.png",


### PR DESCRIPTION
Popfeed is actually available on iOS and Android, but there's no link from their website to their apps.