### PR TITLE
Remove if apps are european from descriptions

### DIFF
--- a/data/apps.json
+++ b/data/apps.json
@@ -64,7 +64,7 @@
   {
     "id": "skywalker",
     "name": "Skywalker",
-    "summary": "European Bluesky client for Android",
+    "summary": "Bluesky client for Android",
     "url": "https://play.google.com/store/apps/details?id=com.gmail.mfnboer.skywalker&hl=en_GB",
     "platforms": ["android"],
     "category": "getting-started",
@@ -80,7 +80,7 @@
   {
     "id": "skeets",
     "name": "Skeets",
-    "summary": "European Bluesky client for iOS",
+    "summary": "Bluesky client for iOS",
     "url": "https://www.skeetsapp.com/",
     "platforms": ["ios"],
     "category": "getting-started",


### PR DESCRIPTION
European apps are already marked as `madeInEU`.
Several apps with that marking do not mention it in their description. One mention, with the tag/pill, is enough.