### PR TITLE
Remove the the from app descriptions

### DIFF
--- a/data/apps.json
+++ b/data/apps.json
@@ -2,7 +2,7 @@
   {
     "id": "bsky",
     "name": "Bluesky",
-    "summary": "The flagship social feed experience",
+    "summary": "Flagship social feed experience",
     "url": "https://bsky.app",
     "platforms": ["ios", "android", "web"],
     "category": "getting-started",
@@ -157,7 +157,7 @@
   {
     "id": "semble",
     "name": "Semble",
-    "summary": "The network for researchers",
+    "summary": "Social knowledge network for researchers",
     "url": "https://semble.so/",
     "platforms": ["web"],
     "category": "for-work",

--- a/data/apps.json
+++ b/data/apps.json
@@ -2,7 +2,7 @@
   {
     "id": "bsky",
     "name": "Bluesky",
-    "summary": "Flagship social feed experience",
+    "summary": "A healthier, thriving alternative to X",
     "url": "https://bsky.app",
     "platforms": ["ios", "android", "web"],
     "category": "getting-started",


### PR DESCRIPTION
Most apps don’t use that `the`.
I think it doesn’t add anything useful.

I didn’t notice Semble before, it’s description was sparse. I added some words from the tagline shown on its own website to clarify it.