### PR TITLE
Fix change password link for pds@0.4.219

### DIFF
--- a/inertia/components/layouts/authenticated.tsx
+++ b/inertia/components/layouts/authenticated.tsx
@@ -41,6 +41,8 @@ export function AuthenticatedLayout(props: { children: ReactElement<Data.SharedP
     return new URL('/account', authorizationServer).toString()
   }, [authorizationServer])
 
+  // FIXME: We're not using `/.well-known/change-password` due to
+  // https://github.com/bluesky-social/atproto/issues/4858
   const changePasswordUrl = useMemo(() => {
     return new URL('/account/password', authorizationServer).toString()
   }, [authorizationServer])

--- a/inertia/components/layouts/authenticated.tsx
+++ b/inertia/components/layouts/authenticated.tsx
@@ -42,7 +42,7 @@ export function AuthenticatedLayout(props: { children: ReactElement<Data.SharedP
   }, [authorizationServer])
 
   const changePasswordUrl = useMemo(() => {
-    return new URL('/.well-known/change-password', authorizationServer).toString()
+    return new URL('/account/password', authorizationServer).toString()
   }, [authorizationServer])
 
   return (


### PR DESCRIPTION
Temporary fix for https://github.com/bluesky-social/atproto/issues/4858

As we only show this link when logged in, and only support the reference PDS image in production, we can get away with temporarily change to use the non-well-known route.