### PR TITLE
Fix release workflow not publishing the tagged version

### DIFF
--- a/.changeset/nine-melons-move.md
+++ b/.changeset/nine-melons-move.md
@@ -1,0 +1,5 @@
+---
+'eurosky-portal': patch
+---
+
+Fix release not publishing

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,13 +1,13 @@
 name: Publish docker image
 
+# We publish the docker image as dev for pushes to main,
+# and we create releases via Changesets for the tags.
 on:
+  release:
+    types: [published]
   push:
-    # We publish the docker image as dev for pushes to main,
-    # and we create releases via Changesets for the tags.
     branches:
       - main
-    tags:
-      - 'v*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
For some reason the workflow triggered on the push but not on the creation of the tag, so I'm trying the release event instead.