### PR TITLE
Fix allowed hosts for redirects

### DIFF
--- a/.changeset/tricky-bars-pump.md
+++ b/.changeset/tricky-bars-pump.md
@@ -1,0 +1,5 @@
+---
+'eurosky-portal': patch
+---
+
+Fix allowed hosts for redirects

--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,6 @@ APP_URL=http://${HOST}:${PORT}
 
 # Session
 SESSION_DRIVER=cookie
-PUBLIC_URL=http://$HOST:$PORT/
 
 OAUTH_SERVICE=https://pds.rip/
 MIGRATION_SERVICE=https://move.eurosky.tech/

--- a/config/app.ts
+++ b/config/app.ts
@@ -18,7 +18,6 @@ export const appKey = env.get('APP_KEY')
  * use absolute URLs.
  */
 export const appUrl = env.get('APP_URL')
-export const publicUrl = env.get('PUBLIC_URL', appUrl)
 
 /**
  * The configuration settings used by the HTTP server
@@ -92,6 +91,6 @@ export const http = defineConfig({
      *
      * Defaults to []
      */
-    allowedHosts: [new URL(publicUrl).host],
+    allowedHosts: [],
   },
 })


### PR DESCRIPTION
This lucky doesn't have production impact, but should be fixed regardless. We can actually rely on the default behavior here.