### PR TITLE
Improve docker image

### DIFF
--- a/.changeset/silly-pears-accept.md
+++ b/.changeset/silly-pears-accept.md
@@ -1,0 +1,11 @@
+---
+'eurosky-portal': patch
+---
+
+Improve dockerfile
+
+- Drops user permissions
+- Uses pnpm fetch to improve install performance
+- Runs dist-upgrade to catch any security updates to the image
+- Installs tini with --no-install-recommends
+- Uses apt caching

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:lts-trixie-slim AS base
+
 # Set default shell used for running commands
 SHELL ["/bin/bash", "-o", "pipefail", "-o", "errexit", "-c"]
 
@@ -7,24 +8,43 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 ENV NODE_ENV=production
 
+RUN \
+  # Remove automatic apt cache Docker cleanup scripts
+  rm -f /etc/apt/apt.conf.d/docker-clean; \
+  # Sets timezone
+  echo "Etc/UTC" > /etc/localtime; \
+  # Creates app user/group and sets home directory
+  groupadd -g "991" app; \
+  useradd -l -u "991" -g "991" -m -d /app app;
+
+RUN \
+  # Mount Apt cache and lib directories from Docker buildx caches
+  --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,id=apt-lib,target=/var/lib/apt,sharing=locked \
+  # Apt update & upgrade to check for security updates to the image
+  apt-get update; \
+  apt-get dist-upgrade -yq; \
+  # Install tini:
+  apt-get install -y --no-install-recommends tini;
+
 FROM base AS base-deps
 WORKDIR /app
 COPY package.json pnpm-*.yaml ./
 
 # Configure Corepack
-RUN \
-  corepack enable; \
-  corepack prepare --activate;
+RUN corepack enable
+
+RUN --mount=type=cache,target=/pnpm/store pnpm fetch
 
 FROM base-deps AS production-deps
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --prod
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --prod --offline
 
 # ----------------------------
 # Stage 2: Build the application
 # ----------------------------
 FROM base-deps AS build
 WORKDIR /app
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline
 COPY . .
 RUN node ace build
 
@@ -32,13 +52,19 @@ RUN node ace build
 # Stage 3: Production runtime
 # ----------------------------
 FROM base AS production
-RUN apt-get update -y && apt-get install -y tini
-
 WORKDIR /app
+
+ENV NODE_ENV=production
+
 # Copy the build app:
 COPY --from=build /app/build ./
 COPY --from=production-deps /app/node_modules ./node_modules/
-ENV NODE_ENV=production
+
+# Setup temporary directory:
+RUN mkdir /app/tmp && chown -R app:app /app/tmp;
+
+# Set the running user for resulting container
+USER app
 
 EXPOSE 4075
 CMD ["tini", "--", "node", "bin/server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN node ace build
 # Stage 3: Production runtime
 # ----------------------------
 FROM base AS production
-RUN apt-get update && apt-get install -y tini
+RUN apt-get update -y && apt-get install -y tini
 
 WORKDIR /app
 # Copy the build app:


### PR DESCRIPTION
We were seeing the following in the docker image build logs, this was due how we were installing tini, so I took a moment to improve the dockerfile overall.

```
#21 [linux/arm64 production 1/4] RUN apt-get update && apt-get install -y tini
#21 42.41 The following NEW packages will be installed:
#21 42.41   tini
#21 42.84 0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
#21 42.84 Need to get 234 kB of archives.
#21 42.84 After this operation, 745 kB of additional disk space will be used.
#21 42.84 Get:1 http://deb.debian.org/debian trixie/main arm64 tini arm64 0.19.0-3+b6 [234 kB]
#21 45.62 debconf: unable to initialize frontend: Dialog
#21 45.62 debconf: (TERM is not set, so the dialog frontend is not usable.)
#21 45.62 debconf: falling back to frontend: Readline
#21 45.63 debconf: unable to initialize frontend: Readline
#21 45.63 debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC entries checked: /etc/perl /usr/local/lib/aarch64-linux-gnu/perl/5.40.1 /usr/local/share/perl/5.40.1 /usr/lib/aarch64-linux-gnu/perl5/5.40 /usr/share/perl5 /usr/lib/aarch64-linux-gnu/perl-base /usr/lib/aarch64-linux-gnu/perl/5.40 /usr/share/perl/5.40 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 8, <STDIN> line 1.)
#21 45.63 debconf: falling back to frontend: Teletype
#21 45.86 debconf: unable to initialize frontend: Teletype
#21 45.86 debconf: (This frontend requires a controlling tty.)
#21 45.86 debconf: falling back to frontend: Noninteractive
#21 ...
```