### PR TITLE
Fix minimum release age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-minimumReleaseAge: 1440

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
+minimumReleaseAge: 1440
 onlyBuiltDependencies:
   - better-sqlite3


### PR DESCRIPTION
* format of npmrc is ini, not yaml
* dependabot is stuck
* value that npm expects is number of days, pnpm uses seconds, maybe this is where dependabot has problems
* more modern pnpm does not read `.npmrc`, but uses `pnpm-workspace.yml`, this seems to work locally for me