### PR TITLE
Update user card on dashboard

### DIFF
--- a/.changeset/fine-bears-yawn.md
+++ b/.changeset/fine-bears-yawn.md
@@ -1,0 +1,5 @@
+---
+'eurosky-portal': patch
+---
+
+Update user card on dashboard

--- a/inertia/components/UserAvatar.tsx
+++ b/inertia/components/UserAvatar.tsx
@@ -3,16 +3,13 @@ import { Avatar } from '~/lib/avatar'
 
 export function UserAvatar({
   avatar,
-  handle,
 }: {
   avatar: Data.Profile['avatar']
-  handle: Data.Account['handle']
 } & React.ComponentPropsWithoutRef<'div'>) {
   return (
     <Avatar
       className={`relative inline-block w-full h-full bg-amber-100 text-amber-700`}
       src={avatar}
-      initials={handle?.slice(0, 2)}
     />
   )
 }

--- a/inertia/lib/avatar.tsx
+++ b/inertia/lib/avatar.tsx
@@ -1,6 +1,6 @@
 import * as Headless from '@headlessui/react'
 import clsx from 'clsx'
-import React, { forwardRef } from 'react'
+import React, { forwardRef, useEffect, useState } from 'react'
 import { ButtonType, TouchTarget } from './button'
 import { Link } from './link'
 import { LinkProps } from '@adonisjs/inertia/react'
@@ -13,6 +13,11 @@ type AvatarProps = {
   className?: string
 }
 
+/**
+ * State of an image.
+ */
+type ImageLoadState = 'error' | 'loaded' | 'loading'
+
 export function Avatar({
   src = null,
   square = false,
@@ -21,6 +26,12 @@ export function Avatar({
   className,
   ...props
 }: AvatarProps & React.ComponentPropsWithoutRef<'span'>) {
+  const [imageLoadState, setImageLoadState] = useState<ImageLoadState>('loading')
+
+  useEffect(() => {
+    setImageLoadState('loading')
+  }, [src])
+
   return (
     <span
       data-slot="avatar"
@@ -36,26 +47,36 @@ export function Avatar({
           : 'rounded-full *:rounded-full'
       )}
     >
-      {initials && (
-        <svg
-          className="size-full fill-current p-[5%] text-[48px] font-medium uppercase select-none"
-          viewBox="0 0 100 100"
-          aria-hidden={alt ? undefined : 'true'}
+      <svg
+        className="size-full fill-current p-[5%] text-[48px] font-medium uppercase select-none"
+        viewBox="0 0 100 100"
+        aria-hidden={alt ? undefined : 'true'}
+        // For transparent images, hide initials when the image is loaded.
+        style={{ display: imageLoadState === 'loaded' ? 'none' : 'block' }}
+      >
+        {alt && <title>{alt}</title>}
+        <text
+          x="50%"
+          y="50%"
+          alignmentBaseline="middle"
+          dominantBaseline="middle"
+          textAnchor="middle"
+          dy={initials ? '.125em' : undefined}
         >
-          {alt && <title>{alt}</title>}
-          <text
-            x="50%"
-            y="50%"
-            alignmentBaseline="middle"
-            dominantBaseline="middle"
-            textAnchor="middle"
-            dy=".125em"
-          >
-            {initials}
-          </text>
-        </svg>
+          {initials || '@'}
+        </text>
+      </svg>
+      {src && (
+        <img
+          className="size-full"
+          onError={() => setImageLoadState('error')}
+          onLoad={() => setImageLoadState('loaded')}
+          // Fall back to initials instead of broken image icon.
+          style={{ display: imageLoadState === 'error' ? 'none' : 'block' }}
+          src={src}
+          alt={alt}
+        />
       )}
-      {src && <img className="size-full" src={src} alt={alt} />}
     </span>
   )
 }

--- a/inertia/pages/dashboard/show.tsx
+++ b/inertia/pages/dashboard/show.tsx
@@ -92,11 +92,11 @@ export default function Dashboard({
           <div className="flex flex-row justify-between">
             <div className="flex flex-row gap-6">
               <div className="size-14 md:size-20 md:self-center">
-                <UserAvatar avatar={profile?.avatar} handle={user.handle} />
+                <UserAvatar avatar={profile?.avatar} />
               </div>
               <div className="flex flex-col">
                 <h2 className="text-lg/8 font-semibold text-zinc-950 sm:text-2xl/8 dark:text-white">
-                  {profile?.displayName ?? user.handle}
+                  Welcome back{profile?.displayName ? ', ' + profile.displayName : ''}!
                 </h2>
                 {isHandleInvalid ? (
                   <Text className="text-amber-500!">


### PR DESCRIPTION
* use `@`, not first 2 characters of handle
* add welcome back prefix before display name
* hide broken image icon if image loading fails

Before:

<img width="800" height="172" alt="Screenshot 2026-06-09 at 12 27 31 PM" src="https://github.com/user-attachments/assets/8650bf77-4209-4259-984f-37799eb81fd2" />
<img width="806" height="176" alt="Screenshot 2026-06-09 at 12 28 12 PM" src="https://github.com/user-attachments/assets/1c6243fb-2a79-46cb-bb70-31628a637bbd" />

After:

<img width="803" height="172" alt="Screenshot 2026-06-25 at 3 03 42 PM" src="https://github.com/user-attachments/assets/2bd639db-5035-42d1-94d5-e716b1e13b3b" />
<img width="803" height="171" alt="Screenshot 2026-06-25 at 3 09 40 PM" src="https://github.com/user-attachments/assets/53fed186-821a-4857-8767-91968e0dba7e" />
