### PR TITLE
Add apps page

### DIFF
--- a/.adonisjs/client/registry/index.ts
+++ b/.adonisjs/client/registry/index.ts
@@ -78,6 +78,12 @@ const routes = {
     tokens: [{"old":"/account/dismiss-welcome","type":0,"val":"account","end":""},{"old":"/account/dismiss-welcome","type":0,"val":"dismiss-welcome","end":""}],
     types: placeholder as Registry['account.dismiss_welcome']['types'],
   },
+  'discover.apps': {
+    methods: ["GET","HEAD"],
+    pattern: '/apps',
+    tokens: [{"old":"/apps","type":0,"val":"apps","end":""}],
+    types: placeholder as Registry['discover.apps']['types'],
+  },
   'legal.show': {
     methods: ["GET","HEAD"],
     pattern: '/legal/:document',

--- a/.adonisjs/client/registry/schema.d.ts
+++ b/.adonisjs/client/registry/schema.d.ts
@@ -151,6 +151,18 @@ export interface Registry {
       errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#controllers/account_controller').default['dismissWelcome']>>>
     }
   }
+  'discover.apps': {
+    methods: ["GET","HEAD"]
+    pattern: '/apps'
+    types: {
+      body: {}
+      paramsTuple: []
+      params: {}
+      query: {}
+      response: ExtractResponse<Awaited<ReturnType<import('#controllers/discover_controller').default['apps']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#controllers/discover_controller').default['apps']>>>
+    }
+  }
   'legal.show': {
     methods: ["GET","HEAD"]
     pattern: '/legal/:document'

--- a/.adonisjs/client/registry/tree.d.ts
+++ b/.adonisjs/client/registry/tree.d.ts
@@ -24,6 +24,9 @@ export interface ApiDefinition {
   explore: {
     learnMore: typeof routes['explore.learn_more']
   }
+  discover: {
+    apps: typeof routes['discover.apps']
+  }
   legal: {
     show: typeof routes['legal.show']
   }

--- a/.adonisjs/server/controllers.ts
+++ b/.adonisjs/server/controllers.ts
@@ -7,6 +7,7 @@ export const controllers = {
   Account: () => import('#controllers/account_controller'),
   Auth: () => import('#controllers/auth_controller'),
   Dashboard: () => import('#controllers/dashboard_controller'),
+  Discover: () => import('#controllers/discover_controller'),
   Explore: () => import('#controllers/explore_controller'),
   Faq: () => import('#controllers/faq_controller'),
   HealthChecks: () => import('#controllers/health_checks_controller'),

--- a/.adonisjs/server/pages.d.ts
+++ b/.adonisjs/server/pages.d.ts
@@ -12,6 +12,7 @@ type ExtractProps<T> =
 
 declare module '@adonisjs/inertia/types' {
   export interface InertiaPages {
+    'apps/show': ExtractProps<(typeof import('../../inertia/pages/apps/show.tsx'))['default']>
     'create-account': ExtractProps<(typeof import('../../inertia/pages/create-account.tsx'))['default']>
     'dashboard/show': ExtractProps<(typeof import('../../inertia/pages/dashboard/show.tsx'))['default']>
     'errors/not_found': ExtractProps<(typeof import('../../inertia/pages/errors/not_found.tsx'))['default']>

--- a/.adonisjs/server/routes.d.ts
+++ b/.adonisjs/server/routes.d.ts
@@ -16,6 +16,7 @@ export type ScannedRoutes = {
     'account.onboarding': { paramsTuple?: []; params?: {} }
     'account.store_acceptance': { paramsTuple?: []; params?: {} }
     'account.dismiss_welcome': { paramsTuple?: []; params?: {} }
+    'discover.apps': { paramsTuple?: []; params?: {} }
     'legal.show': { paramsTuple: [ParamValue]; params: {'document': ParamValue} }
     'faq.show': { paramsTuple?: []; params?: {} }
     'health_checks.live': { paramsTuple?: []; params?: {} }
@@ -29,6 +30,7 @@ export type ScannedRoutes = {
     'dashboard.show': { paramsTuple?: []; params?: {} }
     'explore.learn_more': { paramsTuple?: []; params?: {} }
     'account.onboarding': { paramsTuple?: []; params?: {} }
+    'discover.apps': { paramsTuple?: []; params?: {} }
     'legal.show': { paramsTuple: [ParamValue]; params: {'document': ParamValue} }
     'faq.show': { paramsTuple?: []; params?: {} }
     'health_checks.live': { paramsTuple?: []; params?: {} }
@@ -42,6 +44,7 @@ export type ScannedRoutes = {
     'dashboard.show': { paramsTuple?: []; params?: {} }
     'explore.learn_more': { paramsTuple?: []; params?: {} }
     'account.onboarding': { paramsTuple?: []; params?: {} }
+    'discover.apps': { paramsTuple?: []; params?: {} }
     'legal.show': { paramsTuple: [ParamValue]; params: {'document': ParamValue} }
     'faq.show': { paramsTuple?: []; params?: {} }
     'health_checks.live': { paramsTuple?: []; params?: {} }

--- a/.changeset/eighty-beds-create.md
+++ b/.changeset/eighty-beds-create.md
@@ -1,0 +1,5 @@
+---
+'eurosky-portal': minor
+---
+
+Add apps page

--- a/app/controllers/dashboard_controller.ts
+++ b/app/controllers/dashboard_controller.ts
@@ -1,7 +1,6 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import cache from '@adonisjs/cache/services/main'
 import Apps from '#collections/apps'
-import AppsTransformer from '#transformers/apps_transformer'
 import ProfileTransformer from '#transformers/profile_transformer'
 
 export default class DashboardController {
@@ -25,11 +24,13 @@ export default class DashboardController {
     return inertia.render('dashboard/show', {
       showWelcomeMessage: !account.welcomeDismissed,
       profile: profile ? ProfileTransformer.transform(profile) : undefined,
-      apps: AppsTransformer.transform({
-        gettingStarted: query.findByCategory('getting-started'),
-        exploreMore: query.findByCategory('explore-more'),
-        forWork: query.findByCategory('for-work'),
-      }),
+      // TODO: apps are now static and should be requested/cached/displayed all
+      // together.
+      // If there are detail pages, then it’s a good time to request and cache
+      // per app.
+      // Then this should not use `all().slice()` but something better to only
+      // load what is needed.
+      apps: query.all().slice(0, 3),
     })
   }
 }

--- a/app/controllers/discover_controller.ts
+++ b/app/controllers/discover_controller.ts
@@ -1,0 +1,17 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import Apps from '#collections/apps'
+import AppsTransformer from '#transformers/apps_transformer'
+
+export default class DiscoverController {
+  async apps({ inertia }: HttpContext) {
+    const query = await Apps.load()
+
+    return inertia.render('apps/show', {
+      apps: AppsTransformer.transform({
+        gettingStarted: query.findByCategory('getting-started'),
+        exploreMore: query.findByCategory('explore-more'),
+        forWork: query.findByCategory('for-work'),
+      }),
+    })
+  }
+}

--- a/data/apps.json
+++ b/data/apps.json
@@ -15,34 +15,17 @@
     }
   },
   {
-    "id": "blento",
-    "name": "Blento",
-    "summary": "Create your own website, the fun way",
-    "url": "https://blento.app/",
+    "id": "mu",
+    "name": "mu",
+    "summary": "Eurosky's take on the Bluesky social experience",
+    "url": "https://mu.social",
     "platforms": ["web"],
     "category": "getting-started",
     "madeInEU": true,
     "icon": {
-      "path": "icons/blento.png",
       "fallback": {
-        "color": "purple",
-        "initials": "b"
-      }
-    }
-  },
-  {
-    "id": "flashes",
-    "name": "Flashes",
-    "summary": "Photo and video social sharing",
-    "url": "https://www.flashes.blue",
-    "platforms": ["ios"],
-    "category": "getting-started",
-    "madeInEU": true,
-    "icon": {
-      "path": "icons/flashes.png",
-      "fallback": {
-        "color": "blue",
-        "initials": "fl"
+        "color": "pink",
+        "initials": "mu"
       }
     }
   },
@@ -62,12 +45,90 @@
     }
   },
   {
+    "id": "popfeed",
+    "name": "Popfeed",
+    "summary": "Discover films, TV, games, books and music",
+    "url": "https://popfeed.social/find",
+    "platforms": ["web"],
+    "category": "getting-started",
+    "icon": {
+      "path": "icons/popfeed.png",
+      "fallback": {
+        "color": "purple",
+        "initials": "pf"
+      }
+    }
+  },
+  {
+    "id": "sifa",
+    "name": "Sifa ID",
+    "summary": "Professional profile and networking",
+    "url": "https://sifa.id/",
+    "platforms": ["web"],
+    "category": "getting-started",
+    "madeInEU": true,
+    "icon": {
+      "path": "icons/sifa.png",
+      "fallback": {
+        "color": "gray",
+        "initials": "id"
+      }
+    }
+  },
+  {
+    "id": "streamplace",
+    "name": "Streamplace",
+    "summary": "Easy video streaming from anywhere",
+    "url": "https://stream.place/",
+    "platforms": ["web", "ios", "android"],
+    "category": "getting-started",
+    "icon": {
+      "path": "icons/streamplace.png",
+      "fallback": {
+        "color": "pink",
+        "initials": "sp"
+      }
+    }
+  },
+  {
+    "id": "blento",
+    "name": "Blento",
+    "summary": "Create your own website, the fun way",
+    "url": "https://blento.app/",
+    "platforms": ["web"],
+    "category": "explore-more",
+    "madeInEU": true,
+    "icon": {
+      "path": "icons/blento.png",
+      "fallback": {
+        "color": "purple",
+        "initials": "b"
+      }
+    }
+  },
+  {
+    "id": "flashes",
+    "name": "Flashes",
+    "summary": "Photo and video social sharing",
+    "url": "https://www.flashes.blue",
+    "platforms": ["ios"],
+    "category": "explore-more",
+    "madeInEU": true,
+    "icon": {
+      "path": "icons/flashes.png",
+      "fallback": {
+        "color": "blue",
+        "initials": "fl"
+      }
+    }
+  },
+  {
     "id": "skywalker",
     "name": "Skywalker",
     "summary": "Bluesky client for Android",
     "url": "https://play.google.com/store/apps/details?id=com.gmail.mfnboer.skywalker&hl=en_GB",
     "platforms": ["android"],
-    "category": "getting-started",
+    "category": "explore-more",
     "madeInEU": true,
     "icon": {
       "path": "icons/skywalker.png",
@@ -83,28 +144,13 @@
     "summary": "Bluesky client for iOS",
     "url": "https://www.skeetsapp.com/",
     "platforms": ["ios"],
-    "category": "getting-started",
+    "category": "explore-more",
     "madeInEU": true,
     "icon": {
       "path": "icons/skeets.png",
       "fallback": {
         "color": "blue",
         "initials": "sk"
-      }
-    }
-  },
-  {
-    "id": "popfeed",
-    "name": "Popfeed",
-    "summary": "Discover films, TV, games, books and music",
-    "url": "https://popfeed.social/find",
-    "platforms": ["web"],
-    "category": "explore-more",
-    "icon": {
-      "path": "icons/popfeed.png",
-      "fallback": {
-        "color": "purple",
-        "initials": "pf"
       }
     }
   },
@@ -140,21 +186,6 @@
     }
   },
   {
-    "id": "streamplace",
-    "name": "Streamplace",
-    "summary": "Easy video streaming from anywhere",
-    "url": "https://stream.place/",
-    "platforms": ["web", "ios", "android"],
-    "category": "explore-more",
-    "icon": {
-      "path": "icons/streamplace.png",
-      "fallback": {
-        "color": "pink",
-        "initials": "sp"
-      }
-    }
-  },
-  {
     "id": "semble",
     "name": "Semble",
     "summary": "Social knowledge network for researchers",
@@ -182,22 +213,6 @@
       "fallback": {
         "color": "gray",
         "initials": "t"
-      }
-    }
-  },
-  {
-    "id": "sifa",
-    "name": "Sifa ID",
-    "summary": "Professional profile and networking",
-    "url": "https://sifa.id/",
-    "platforms": ["web"],
-    "category": "for-work",
-    "madeInEU": true,
-    "icon": {
-      "path": "icons/sifa.png",
-      "fallback": {
-        "color": "gray",
-        "initials": "id"
       }
     }
   }

--- a/inertia/components/AppGrid.tsx
+++ b/inertia/components/AppGrid.tsx
@@ -1,0 +1,15 @@
+import { Data } from '@generated/data'
+import { App } from '~/components/App'
+
+export function AppGrid({ apps }: { apps: Data.App[] }) {
+  return (
+    <ul
+      role="list"
+      className="mt-4 mb-8 grid grid-cols-1 gap-5 sm:gap-6 sm:grid-cols-2 md:grid-cols-3"
+    >
+      {apps.map((app) => (
+        <App key={app.id} app={app} />
+      ))}
+    </ul>
+  )
+}

--- a/inertia/components/Apps.tsx
+++ b/inertia/components/Apps.tsx
@@ -1,14 +1,14 @@
 import { Data } from '@generated/data'
-import { App } from '~/components/App'
+import { AppGrid } from '~/components/AppGrid'
 
-export type Apps = {
+type Apps = {
   gettingStarted: Data.App[]
   exploreMore: Data.App[]
   forWork: Data.App[]
 }
 
 export function Apps({ apps }: { apps: Apps }) {
-  const headingStyle = 'text-lg font-semibold text-neutral-400 dark:text-slate-400'
+  const headingStyle = 'mt-8 mb-4 text-lg font-semibold text-neutral-400 dark:text-slate-400'
 
   return (
     <>
@@ -21,18 +21,5 @@ export function Apps({ apps }: { apps: Apps }) {
       <h3 className={headingStyle}>For work</h3>
       <AppGrid apps={apps.forWork} />
     </>
-  )
-}
-
-function AppGrid({ apps }: { apps: Data.App[] }) {
-  return (
-    <ul
-      role="list"
-      className="mt-4 mb-8 grid grid-cols-1 gap-5 sm:gap-6 sm:grid-cols-2 md:grid-cols-3"
-    >
-      {apps.map((app) => (
-        <App key={app.id} app={app} />
-      ))}
-    </ul>
   )
 }

--- a/inertia/components/layouts/authenticated.tsx
+++ b/inertia/components/layouts/authenticated.tsx
@@ -19,6 +19,7 @@ import {
   ChatBubbleOvalLeftEllipsisIcon,
   DocumentTextIcon,
   Cog6ToothIcon,
+  GlobeAltIcon,
   ArrowTopRightOnSquareIcon,
   LifebuoyIcon,
   LockClosedIcon,
@@ -77,6 +78,13 @@ export function AuthenticatedLayout(props: { children: ReactElement<Data.SharedP
                       Change Password{' '}
                       <ArrowTopRightOnSquareIcon className="size-4 inline-block self-center" />
                     </SidebarLabel>
+                  </SidebarItem>
+                </SidebarSection>
+                <SidebarHeading className="mt-10 font-bold">Discover</SidebarHeading>
+                <SidebarSection>
+                  <SidebarItem href="/apps" current={url == '/apps'}>
+                    <GlobeAltIcon />
+                    <SidebarLabel>Applications</SidebarLabel>
                   </SidebarItem>
                 </SidebarSection>
                 <SidebarHeading className="mt-10 font-bold">Support</SidebarHeading>

--- a/inertia/pages/apps/show.tsx
+++ b/inertia/pages/apps/show.tsx
@@ -1,0 +1,28 @@
+import { Data } from '@generated/data'
+import { Head } from '@inertiajs/react'
+import { Apps } from '~/components/Apps'
+import Card from '~/lib/card'
+import { InertiaProps } from '~/types'
+
+export default function ApplicationsPage({
+  apps,
+}: InertiaProps<{
+  apps: {
+    gettingStarted: Data.App[]
+    exploreMore: Data.App[]
+    forWork: Data.App[]
+  }
+}>) {
+  return (
+    <Card className="py-3 px-4">
+      <Head title="Applications" />
+      <h2 className="mt-2 mb-4 text-lg/8 sm:text-3xl/8 font-semibold text-gray-900 dark:text-gray-200">
+        Applications
+      </h2>
+      <p className="mb-4 text-sm/6 text-gray-500 dark:text-gray-300">
+        Browse featured apps that work with your Eurosky account.
+      </p>
+      <Apps apps={apps} />
+    </Card>
+  )
+}

--- a/inertia/pages/dashboard/show.tsx
+++ b/inertia/pages/dashboard/show.tsx
@@ -6,7 +6,7 @@ import { Text } from '~/lib/text'
 import { InertiaProps } from '~/types'
 import { useAuth } from '~/utils/use_auth'
 import { Data } from '@generated/data'
-import { Apps } from '~/components/Apps'
+import { AppGrid } from '~/components/AppGrid'
 import { client } from '~/client'
 import { useRouter } from '@adonisjs/inertia/react'
 import { INVALID_HANDLE } from '@atproto/syntax'
@@ -19,11 +19,7 @@ export default function Dashboard({
 }: InertiaProps<{
   showWelcomeMessage: boolean
   profile: Data.Profile | undefined
-  apps: {
-    gettingStarted: Data.App[]
-    exploreMore: Data.App[]
-    forWork: Data.App[]
-  }
+  apps: Data.App[]
 }>) {
   const user = useAuth()
   const router = useRouter()
@@ -150,14 +146,20 @@ export default function Dashboard({
         </Card>
       </div>
       <div className="pt-4">
-        <h2 className="text-xl text-center font-medium text-neutral-500 dark:text-slate-200">
+        <h2 className="text-xl font-medium text-neutral-500 dark:text-slate-200">
           Featured applications
         </h2>
-        <p className="text-center text-base md:textlg text-neutral-400 dark:text-slate-400 mb-6">
+        <p className="text-base text-neutral-400 dark:text-slate-400 mb-6">
           Your Eurosky account works with all of these.
         </p>
 
-        <Apps apps={apps} />
+        <AppGrid apps={apps} />
+
+        <div className="mt-1 flex justify-center">
+          <Button route="discover.apps" className="w-full sm:w-auto dark:bg-slate-700!">
+            Browse more apps
+          </Button>
+        </div>
       </div>
     </div>
   )

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -31,6 +31,7 @@ router
   })
   .use([middleware.auth(), middleware.legalRoadblock()])
 
+router.get('/apps', [controllers.Discover, 'apps'])
 router.get('/legal/:document', [controllers.Legal, 'show'])
 router.get('/faq', [controllers.Faq, 'show'])
 


### PR DESCRIPTION
This moves apps to a dedicated page.
Available in the sidebar under `Discover > Applications` and through a preview of 3 apps and a link to the full page on the dashboard.

Notes:

* `/apps`? `/applications`? `/discover/...`?
* this is a good moment to think about which apps to show on the dashboard:
  * maybe mu, bsky, and one other?
  * could be random, all 3 or mu+bsky+random?
* instead of 3, I think I prefer say 6 for now, while there are no sections below it

Before:

<img width="1648" height="1072" alt="before" src="https://github.com/user-attachments/assets/1b816d87-b2b5-45f0-ad2a-a3e98b95c668" />

After:

<img width="1648" height="1072" alt="after-1" src="https://github.com/user-attachments/assets/1a1a8e76-c363-4919-92fe-e99b213e9372" />

<img width="1648" height="1072" alt="after-2" src="https://github.com/user-attachments/assets/a8505bac-143b-4ee6-9e21-9ee3414c2f60" />
