### PR TITLE
Remove publishing to docker on forks

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   release:
     name: Publish docker image
+    if: github.repository == 'eurosky-social/eurosky-portal'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
The `release.yaml` file has [this guard](https://github.com/eurosky-social/eurosky-portal/blob/e729a1e0825f97149686d5be288f04305a3302e3/.github/workflows/release.yaml#L21), to not do things on forks.
But on forks the “Publish docker image” currently runs, which fails.
This should hide that “failed workflow” notification for forks.

Example of a failed workflow: https://github.com/wooorm/eurosky-portal/actions/runs/28437031738