### PR TITLE
Update list of apps

### DIFF
--- a/.changeset/lazy-maps-tell.md
+++ b/.changeset/lazy-maps-tell.md
@@ -1,0 +1,5 @@
+---
+'eurosky-portal': patch
+---
+
+Update list of apps

--- a/app/controllers/dashboard_controller.ts
+++ b/app/controllers/dashboard_controller.ts
@@ -6,7 +6,7 @@ import ProfileTransformer from '#transformers/profile_transformer'
 export default class DashboardController {
   async show({ auth, inertia }: HttpContext) {
     const atstore = new AtStoreService()
-    const apps = await atstore.getApps()
+    const apps = await atstore.getFeaturedApps()
     const user = await auth.getUserOrFail()
     const account = await user.getAccount()
     const profile = await cache.getOrSet({
@@ -25,6 +25,7 @@ export default class DashboardController {
     return inertia.render('dashboard/show', {
       showWelcomeMessage: !account.welcomeDismissed,
       profile: profile ? ProfileTransformer.transform(profile) : undefined,
+      // Hard cap at 3.
       apps: apps.slice(0, 3),
     })
   }

--- a/app/controllers/discover_controller.ts
+++ b/app/controllers/discover_controller.ts
@@ -7,12 +7,6 @@ export default class DiscoverController {
     const atstore = new AtStoreService()
     const apps = await atstore.getApps()
 
-    return inertia.render('apps/show', {
-      apps: AppsTransformer.transform({
-        gettingStarted: atstore.findByCategory(apps, 'getting-started'),
-        exploreMore: atstore.findByCategory(apps, 'explore-more'),
-        forWork: atstore.findByCategory(apps, 'for-work'),
-      }),
-    })
+    return inertia.render('apps/show', new AppsTransformer({ apps }).toObject())
   }
 }

--- a/app/controllers/home_controller.ts
+++ b/app/controllers/home_controller.ts
@@ -7,12 +7,6 @@ export default class HomeController {
     const atstore = new AtStoreService()
     const apps = await atstore.getApps()
 
-    return inertia.render('home', {
-      apps: AppsTransformer.transform({
-        gettingStarted: atstore.findByCategory(apps, 'getting-started'),
-        exploreMore: atstore.findByCategory(apps, 'explore-more'),
-        forWork: atstore.findByCategory(apps, 'for-work'),
-      }),
-    })
+    return inertia.render('home', new AppsTransformer({ apps }).toObject())
   }
 }

--- a/app/services/atstore_service.ts
+++ b/app/services/atstore_service.ts
@@ -8,9 +8,6 @@ import type { Infer } from '@vinejs/vine/types'
 import vine from '@vinejs/vine'
 import * as lexicon from '#lexicons'
 
-const categories = ['getting-started', 'explore-more', 'for-work'] as const
-export type Category = (typeof categories)[number]
-
 type ListingCardGet = lexicon.fyi.atstore.directory.getListing.ListingCardGet
 
 /**
@@ -47,9 +44,36 @@ type AtStoreListing = Pick<
  * Use the `at://…` url you see there as the `atUri` in `data/apps.json`.
  */
 const localAppSchema = vine.object({
-  atUri: vine.string().startsWith('at://'),
-  category: vine.enum(categories),
-  madeInEU: vine.boolean().optional(),
+  /**
+   * Human-readable label for the entry; not used other than to make logs more
+   * readable.
+   */
+  '#': vine.string().optional(),
+
+  /**
+   * URI to atstore.
+   */
+  'atUri': vine.string().startsWith('at://'),
+
+  /**
+   * Category slug (example: `getting-started`).
+   */
+  'category': vine.string().trim().minLength(1),
+
+  /**
+   * Apps to show “outside” of the `apps` page.
+   */
+  'featured': vine.boolean().optional(),
+
+  /**
+   * Stamp of approval.
+   */
+  'madeInEurope': vine.boolean().optional(),
+
+  /**
+   * Custom category: apps recommended by eurosky.
+   */
+  'recommended': vine.boolean().optional(),
 })
 
 const localAppsValidator = vine.create(vine.array(localAppSchema))
@@ -64,42 +88,18 @@ export class AtStoreService {
   private baseUrl = 'https://atstore.fyi'
 
   /**
-   * Get apps from local `data/apps.json` and augment with remote info.
+   * Get all local apps and augment with remote info.
    */
   async getApps(): Promise<ReadonlyArray<App>> {
-    const filePath = app.makePath('data', 'apps.json')
-    const local = await localAppsValidator.validate(JSON.parse(await readFile(filePath, 'utf8')))
-    const list = await Promise.allSettled(
-      local.map((localApp) =>
-        cache.getOrSet({
-          factory: async () => {
-            const listing = await this.#fetchListing(localApp.atUri)
-            return { ...listing, ...localApp }
-          },
-          graceBackoff: '15m',
-          grace: '24h',
-          key: `atstore:listing:${localApp.atUri}`,
-          ttl: '4h',
-        })
-      )
-    )
-
-    return list
-      .map((result) => {
-        if (result.status === 'fulfilled') {
-          return result.value
-        } else {
-          logger.warn('Failed to fetch app listing', { error: result.reason })
-        }
-      })
-      .filter((a): a is App => a !== undefined)
+    return this.#hydrateAll(await this.#getLocalApps())
   }
 
   /**
-   * Find apps by category.
+   * Get local apps flagged as `featured` and augmented with remote info.
    */
-  findByCategory(apps: ReadonlyArray<App>, category: Category): Array<App> {
-    return apps.filter((a) => a.category === category)
+  async getFeaturedApps(): Promise<ReadonlyArray<App>> {
+    const local = await this.#getLocalApps()
+    return this.#hydrateAll(local.filter((a) => a.featured))
   }
 
   /**
@@ -124,5 +124,50 @@ export class AtStoreService {
     const { externalUrl, listing } = result.body
     const { iconUrl, name, rating, reviewCount, tagline } = listing
     return { externalUrl, listing: { iconUrl, name, rating, reviewCount, tagline } }
+  }
+
+  /**
+   * Read and validate local apps from `data/apps.json`.
+   */
+  async #getLocalApps(): Promise<ReadonlyArray<LocalApp>> {
+    const filePath = app.makePath('data', 'apps.json')
+    return localAppsValidator.validate(JSON.parse(await readFile(filePath, 'utf8')))
+  }
+
+  /**
+   * Augment apps with remote info.
+   *
+   * Skips and logs any that fail.
+   */
+  async #hydrateAll(local: ReadonlyArray<LocalApp>): Promise<ReadonlyArray<App>> {
+    const list = await Promise.allSettled(local.map((localApp) => this.#hydrate(localApp)))
+
+    return list
+      .map((result, index) => {
+        if (result.status === 'fulfilled') {
+          return result.value
+        } else {
+          const localApp = local[index]
+          const label = localApp['#'] ?? localApp.atUri
+          logger.warn({ error: result.reason }, `Failed to fetch listing \`${label}\``)
+        }
+      })
+      .filter((a): a is App => a !== undefined)
+  }
+
+  /**
+   * Augment an app with remote info.
+   */
+  async #hydrate(localApp: LocalApp): Promise<App> {
+    return cache.getOrSet({
+      factory: async () => {
+        const listing = await this.#fetchListing(localApp.atUri)
+        return { ...listing, ...localApp }
+      },
+      graceBackoff: '15m',
+      grace: '24h',
+      key: `atstore:listing:${localApp.atUri}`,
+      ttl: '4h',
+    })
   }
 }

--- a/app/transformers/app_transformer.ts
+++ b/app/transformers/app_transformer.ts
@@ -3,6 +3,6 @@ import { BaseTransformer } from '@adonisjs/core/transformers'
 
 export default class AppTransformer extends BaseTransformer<App> {
   toObject() {
-    return this.pick(this.resource, ['atUri', 'externalUrl', 'listing', 'madeInEU'])
+    return this.pick(this.resource, ['atUri', 'externalUrl', 'listing', 'madeInEurope'])
   }
 }

--- a/app/transformers/apps_transformer.ts
+++ b/app/transformers/apps_transformer.ts
@@ -3,15 +3,34 @@ import type { App } from '#services/atstore_service'
 import AppTransformer from '#transformers/app_transformer'
 
 export default class AppsTransformer extends BaseTransformer<{
-  gettingStarted: App[]
-  exploreMore: App[]
-  forWork: App[]
+  apps: ReadonlyArray<App>
 }> {
   toObject() {
+    const byCategory = new Map<string, App[]>()
+    const recommended: App[] = []
+
+    for (const app of this.resource.apps) {
+      const apps = byCategory.get(app.category) ?? []
+      apps.push(app)
+      byCategory.set(app.category, apps)
+      if (app.recommended) recommended.push(app)
+    }
+
+    const categories = [...byCategory.entries()]
+      .map(([category, apps]) => ({ apps, category }))
+      .sort((a, b) => a.category.localeCompare(b.category))
+    const sections =
+      recommended.length > 0
+        ? [{ apps: recommended, category: 'recommended' }, ...categories]
+        : categories
+
     return {
-      gettingStarted: AppTransformer.transform(this.resource.gettingStarted),
-      exploreMore: AppTransformer.transform(this.resource.exploreMore),
-      forWork: AppTransformer.transform(this.resource.forWork),
+      sections: sections.map(({ category, apps }) => ({
+        apps: [...apps]
+          .sort((a, b) => a.listing.name.localeCompare(b.listing.name))
+          .map((app) => new AppTransformer(app).toObject()),
+        category,
+      })),
     }
   }
 }

--- a/data/apps.json
+++ b/data/apps.json
@@ -1,75 +1,175 @@
 [
   {
-    "#": "Bluesky; note: for more info see `services/atstore_service.ts`",
-    "atUri": "at://did:plc:dvy6bdnofdfc4php4s5b457d/fyi.atstore.listing.detail/3mj667g65ct2x",
-    "category": "getting-started"
+    "#": "atmo.rsvp",
+    "atUri": "at://did:plc:b63bmauox6z5rbibwrhxrdnw/fyi.atstore.listing.detail/3moebodfjt2oq",
+    "category": "events",
+    "madeInEurope": true,
+    "recommended": true
   },
   {
-    "#": "Leaflet; to do: add `mu` above",
-    "atUri": "at://did:plc:btxrwcaeyodrap5mnjw2fvmz/fyi.atstore.listing.detail/3mkijfr6sts5l",
-    "category": "getting-started"
-  },
-  {
-    "#": "Popfeed",
-    "atUri": "at://did:plc:dvy6bdnofdfc4php4s5b457d/fyi.atstore.listing.detail/3mj66fhgmnh2x",
-    "category": "getting-started"
-  },
-  {
-    "#": "Sifa ID",
-    "atUri": "at://did:plc:2f2ahswozqy4v5lvu676375y/fyi.atstore.listing.detail/3mkduyazhqc6y",
-    "category": "getting-started",
-    "madeInEU": true
-  },
-  {
-    "#": "Stream.place",
-    "atUri": "at://did:plc:rbvrr34edl5ddpuwcubjiost/fyi.atstore.listing.detail/3mkijapfmwcvs",
-    "category": "getting-started"
+    "#": "Atstore",
+    "atUri": "at://did:plc:dvy6bdnofdfc4php4s5b457d/fyi.atstore.listing.detail/3mkjss6n7vuza",
+    "category": "reviews"
   },
   {
     "#": "Blento",
     "atUri": "at://did:plc:4fdwezqvlw4mu2qwn7wqsmej/fyi.atstore.listing.detail/3mkk4kacxbk3a",
-    "category": "explore-more",
-    "madeInEU": true
+    "category": "personal-page",
+    "featured": true,
+    "madeInEurope": true
+  },
+  {
+    "#": "Bookhive",
+    "atUri": "at://did:plc:enu2j5xjlqsjaylv3du4myh4/fyi.atstore.listing.detail/3mkigtshwosb3",
+    "category": "reviews"
+  },
+  {
+    "#": "Chive",
+    "atUri": "at://did:plc:7natp5xae72bddaqlkef2t4e/fyi.atstore.listing.detail/3mkkxgeomikmf",
+    "category": "read-and-write"
+  },
+  {
+    "#": "Colibri",
+    "atUri": "at://did:plc:mprdjqjluoswa7awzggaggj3/fyi.atstore.listing.detail/3mkiem5w5k2l6",
+    "category": "social"
+  },
+  {
+    "#": "Currents",
+    "atUri": "at://did:plc:jaur46k6ijyfvl4lojza7eic/fyi.atstore.listing.detail/3mkl2pbqle2p6",
+    "category": "photo-and-video"
   },
   {
     "#": "Flashes",
     "atUri": "at://did:plc:24kqkpfy6z7avtgu3qg57vvl/fyi.atstore.listing.detail/3mkizzu7lp2a3",
-    "category": "explore-more",
-    "madeInEU": true
+    "category": "photo-and-video",
+    "madeInEurope": true,
+    "recommended": true
   },
   {
-    "#": "Skywalker",
-    "atUri": "at://did:plc:zzmeflm2wzrrgcaam6bw3kaf/fyi.atstore.listing.detail/3mkpls2aa62c3",
-    "category": "explore-more",
-    "madeInEU": true
+    "#": "Germ",
+    "atUri": "at://did:plc:4yvwfwxfz5sney4twepuzdu7/fyi.atstore.listing.detail/3ml2bxdff2kv7",
+    "category": "social"
   },
   {
-    "#": "Skeets",
-    "atUri": "at://did:plc:dvy6bdnofdfc4php4s5b457d/fyi.atstore.listing.detail/3mj66gqhdkq2f",
-    "category": "explore-more",
-    "madeInEU": true
+    "#": "Glean",
+    "atUri": "at://did:plc:7fx3svzgnlvzighbczz3mmsd/fyi.atstore.listing.detail/3mklb6venl2dg",
+    "category": "read-and-write"
   },
   {
-    "#": "Sill",
-    "atUri": "at://did:plc:ryed5tnzwmpwbidrsuwrlwwb/fyi.atstore.listing.detail/3mkkdlphhxkgj",
-    "category": "explore-more",
-    "madeInEU": true
+    "#": "Grain",
+    "atUri": "at://did:plc:e7rftrdyz5e2rw4y6ocszew2/fyi.atstore.listing.detail/3mkinhlyjfk55",
+    "category": "photo-and-video",
+    "recommended": true
   },
   {
-    "#": "atmo.rsvp",
-    "atUri": "at://did:plc:b63bmauox6z5rbibwrhxrdnw/fyi.atstore.listing.detail/3moebodfjt2oq",
-    "category": "explore-more",
-    "madeInEU": true
+    "#": "kipclip",
+    "atUri": "at://did:plc:3zzkrrjtsmo7nnwnvhex3auj/fyi.atstore.listing.detail/3mkip5bumt2p5",
+    "category": "bookmark"
+  },
+  {
+    "#": "Leaflet",
+    "atUri": "at://did:plc:btxrwcaeyodrap5mnjw2fvmz/fyi.atstore.listing.detail/3mkijfr6sts5l",
+    "category": "read-and-write"
+  },
+  {
+    "#": "Margin",
+    "atUri": "at://did:plc:rjqn3agdb74cszhqcpii4sne/fyi.atstore.listing.detail/3mkid4nadskrz",
+    "category": "bookmark"
+  },
+  {
+    "#": "Marque; TODO: add `mu` below (`social`, `recommended`, `featured`, `madeInEurope`)",
+    "atUri": "at://did:plc:nckosudltxrtrjkt4zz4jy5y/fyi.atstore.listing.detail/3mlweswilzk3p",
+    "category": "development"
+  },
+  {
+    "#": "npmx",
+    "atUri": "at://did:plc:u5zp7npt5kpueado77kuihyz/fyi.atstore.listing.detail/3mknyydlui2jc",
+    "category": "development",
+    "madeInEurope": true
+  },
+  {
+    "#": "Offprint",
+    "atUri": "at://did:plc:pgjkomf37an4czloay5zeth6/fyi.atstore.listing.detail/3mkni5k5q5kxx",
+    "category": "read-and-write"
+  },
+  {
+    "#": "pckt",
+    "atUri": "at://did:plc:revjuqmkvrw6fnkxppqtszpv/fyi.atstore.listing.detail/3mkkyjyup6kdv",
+    "category": "read-and-write",
+    "featured": true,
+    "recommended": true
+  },
+  {
+    "#": "Popfeed",
+    "atUri": "at://did:plc:dvy6bdnofdfc4php4s5b457d/fyi.atstore.listing.detail/3mj66fhgmnh2x",
+    "category": "reviews",
+    "recommended": true
   },
   {
     "#": "Semble",
     "atUri": "at://did:plc:k7wclckeajmuibxbamtbejjg/fyi.atstore.listing.detail/3mkiitkc44spk",
-    "category": "for-work"
+    "category": "bookmark"
+  },
+  {
+    "#": "Sifa ID",
+    "atUri": "at://did:plc:2f2ahswozqy4v5lvu676375y/fyi.atstore.listing.detail/3mkduyazhqc6y",
+    "category": "personal-page",
+    "madeInEurope": true,
+    "recommended": true
+  },
+  {
+    "#": "Sill",
+    "atUri": "at://did:plc:ryed5tnzwmpwbidrsuwrlwwb/fyi.atstore.listing.detail/3mkkdlphhxkgj",
+    "category": "read-and-write",
+    "recommended": true
+  },
+  {
+    "#": "Skeets",
+    "atUri": "at://did:plc:dvy6bdnofdfc4php4s5b457d/fyi.atstore.listing.detail/3mj66gqhdkq2f",
+    "category": "social",
+    "madeInEurope": true
+  },
+  {
+    "#": "Skylights",
+    "atUri": "at://did:plc:4adlzwqtkv4dirxjwq4c3tlm/fyi.atstore.listing.detail/3mknw3yzlz2bp",
+    "category": "photo-and-video"
+  },
+  {
+    "#": "Skywalker",
+    "atUri": "at://did:plc:zzmeflm2wzrrgcaam6bw3kaf/fyi.atstore.listing.detail/3mkpls2aa62c3",
+    "category": "social",
+    "madeInEurope": true
+  },
+  {
+    "#": "Smoke signal",
+    "atUri": "at://did:plc:dvy6bdnofdfc4php4s5b457d/fyi.atstore.listing.detail/3mj66hobtig2d",
+    "category": "events"
+  },
+  {
+    "#": "Spark",
+    "atUri": "at://did:plc:cveom2iroj3mt747sd4qqnr2/fyi.atstore.listing.detail/3mkqg5sf3gsde",
+    "category": "photo-and-video"
+  },
+  {
+    "#": "Standard reader",
+    "atUri": "at://did:plc:f4os2wz5fjl56xpwcvtnqu7m/fyi.atstore.listing.detail/3mpjb3fty62nt",
+    "category": "read-and-write",
+    "recommended": true
+  },
+  {
+    "#": "Stream.place",
+    "atUri": "at://did:plc:rbvrr34edl5ddpuwcubjiost/fyi.atstore.listing.detail/3mkijapfmwcvs",
+    "category": "photo-and-video"
   },
   {
     "#": "Tangled",
     "atUri": "at://did:plc:dvy6bdnofdfc4php4s5b457d/fyi.atstore.listing.detail/3mj66idq2fp2t",
-    "category": "for-work",
-    "madeInEU": true
+    "category": "development",
+    "madeInEurope": true
+  },
+  {
+    "#": "Wisp",
+    "atUri": "at://did:plc:7puq73yz2hkvbcpdhnsze2qw/fyi.atstore.listing.detail/3mkqaxwdkz2mp",
+    "category": "development"
   }
 ]

--- a/inertia/components/App.tsx
+++ b/inertia/components/App.tsx
@@ -43,9 +43,9 @@ export function App({ app }: { app: Data.App }) {
           </div>
         ) : undefined}
         <div className="flex w-full items-center gap-2">
-          {app.madeInEU ? (
+          {app.madeInEurope ? (
             <Badge color="blue" className="ml-auto">
-              Made in the EU
+              Made in Europe
             </Badge>
           ) : undefined}
         </div>

--- a/inertia/components/Apps.tsx
+++ b/inertia/components/Apps.tsx
@@ -1,25 +1,38 @@
 import { Data } from '@generated/data'
 import { AppGrid } from '~/components/AppGrid'
 
-type Apps = {
-  gettingStarted: Data.App[]
-  exploreMore: Data.App[]
-  forWork: Data.App[]
-}
-
-export function Apps({ apps }: { apps: Apps }) {
+export function Apps({ sections }: { sections: Data.Apps['sections'] }) {
   const headingStyle = 'mt-8 mb-4 text-lg font-semibold text-neutral-400 dark:text-slate-400'
 
   return (
     <>
-      <h3 className={headingStyle}>Getting started</h3>
-      <AppGrid apps={apps.gettingStarted} />
-
-      <h3 className={headingStyle}>Explore more</h3>
-      <AppGrid apps={apps.exploreMore} />
-
-      <h3 className={headingStyle}>For work</h3>
-      <AppGrid apps={apps.forWork} />
+      {sections.map(
+        (section) =>
+          section.apps.length > 0 && (
+            <div key={section.category}>
+              <h3 className={headingStyle}>{categoryTitle(section.category)}</h3>
+              <AppGrid apps={section.apps} />
+            </div>
+          )
+      )}
     </>
   )
+}
+
+/**
+ * Turn a slug such as `getting-started` into a title such as `Getting started`.
+ *
+ * Very basic; should be fine for now.
+ */
+function categoryTitle(value: string): string {
+  const words = value.split('-')
+  let index = -1
+
+  while (++index < words.length) {
+    const word = words[index]
+    if (word === 'and') words[index] = '&'
+  }
+
+  const title = words.join(' ')
+  return title.charAt(0).toUpperCase() + title.slice(1)
 }

--- a/inertia/lib/avatar.tsx
+++ b/inertia/lib/avatar.tsx
@@ -1,6 +1,6 @@
 import * as Headless from '@headlessui/react'
 import clsx from 'clsx'
-import React, { forwardRef, useEffect, useState } from 'react'
+import React, { forwardRef, useState } from 'react'
 import { ButtonType, TouchTarget } from './button'
 import { Link } from './link'
 import { LinkProps } from '@adonisjs/inertia/react'
@@ -26,11 +26,15 @@ export function Avatar({
   className,
   ...props
 }: AvatarProps & React.ComponentPropsWithoutRef<'span'>) {
+  // Reset during render when `src` changes so this does not race with `load`
+  // on `<img>` and gets stuck showing both the image and the fallback.
+  const [prevSrc, setPrevSrc] = useState(src)
   const [imageLoadState, setImageLoadState] = useState<ImageLoadState>('loading')
 
-  useEffect(() => {
+  if (src !== prevSrc) {
+    setPrevSrc(src)
     setImageLoadState('loading')
-  }, [src])
+  }
 
   return (
     <span

--- a/inertia/pages/apps/show.tsx
+++ b/inertia/pages/apps/show.tsx
@@ -4,15 +4,7 @@ import { Apps } from '~/components/Apps'
 import Card from '~/lib/card'
 import { InertiaProps } from '~/types'
 
-export default function ApplicationsPage({
-  apps,
-}: InertiaProps<{
-  apps: {
-    gettingStarted: Data.App[]
-    exploreMore: Data.App[]
-    forWork: Data.App[]
-  }
-}>) {
+export default function ApplicationsPage({ sections }: InertiaProps<Data.Apps>) {
   return (
     <Card className="py-3 px-4">
       <Head title="Applications" />
@@ -22,7 +14,7 @@ export default function ApplicationsPage({
       <p className="mb-4 text-sm/6 text-gray-500 dark:text-gray-300">
         Browse featured apps that work with your Eurosky account.
       </p>
-      <Apps apps={apps} />
+      <Apps sections={sections} />
     </Card>
   )
 }

--- a/inertia/pages/home.tsx
+++ b/inertia/pages/home.tsx
@@ -4,15 +4,7 @@ import { Data } from '@generated/data'
 import { Container } from '~/lib/container'
 import { Apps } from '~/components/Apps'
 
-export default function Home({
-  apps,
-}: InertiaProps<{
-  apps: {
-    gettingStarted: Data.App[]
-    exploreMore: Data.App[]
-    forWork: Data.App[]
-  }
-}>) {
+export default function Home({ sections }: InertiaProps<Data.Apps>) {
   return (
     <>
       <Hero />
@@ -24,15 +16,7 @@ export default function Home({
           There's always new apps being created!
         </p>
 
-        <Apps apps={apps} />
-
-        {/* <Card className="w-full focus:outline-hidden p-4 items-center flex flex-col outline-offset-0! outline-2! outline-dashed outline-gray-300 dark:outline-white/20 shadow-none!">
-          <PlusIcon className="size-12 p-2 mb-2 text-slate-400" />
-          <Heading level={4} className="text-base!">
-            More coming
-          </Heading>
-          <Text className="text-center">There's always new apps being created!</Text>
-        </Card> */}
+        <Apps sections={sections} />
       </Container>
     </>
   )


### PR DESCRIPTION
* basically a bunch of new apps from the spreadsheet
* categories can be anything, come from the data, not just 3 hardcoded ones
* a special category through a `recommended` flag appears first
* some apps have a local `featured` flag, making them appear on the logged in user dashboard (2 or 3 )
* better data management for those featured ones, they don’t require the whole lookup first
* fixed a bug for transparent avatars overlayed on their fallback text
* `Made in the EU` -> `Made in Europe`

Screenshot:

<img width="1648" height="1072" alt="Screenshot 2026-07-02 at 4 41 38 PM" src="https://github.com/user-attachments/assets/de87bdfc-0a75-4639-8f90-26124636e4ac" />
