### PR TITLE
Update changePasswordUrl to point to correct endpoint

### DIFF
--- a/.changeset/fix-change-password.md
+++ b/.changeset/fix-change-password.md
@@ -1,0 +1,5 @@
+---
+'eurosky-portal': patch
+---
+
+Fix change password link, which became broken due to the same issue.

--- a/inertia/components/layouts/authenticated.tsx
+++ b/inertia/components/layouts/authenticated.tsx
@@ -44,7 +44,7 @@ export function AuthenticatedLayout(props: { children: ReactElement<Data.SharedP
   // FIXME: We're not using `/.well-known/change-password` due to
   // https://github.com/bluesky-social/atproto/issues/4858
   const changePasswordUrl = useMemo(() => {
-    return new URL('/account/password', authorizationServer).toString()
+    return new URL('/account/manage', authorizationServer).toString()
   }, [authorizationServer])
 
   return (


### PR DESCRIPTION
We accidentally broke this when redesigning the PDS admin, due to the same /.well-known/change-password issue — a longer term fix is coming though.