### PR TITLE
Add app detail page

### DIFF
--- a/.adonisjs/client/data.d.ts
+++ b/.adonisjs/client/data.d.ts
@@ -7,6 +7,7 @@
 import type { InferData, InferVariants } from '@adonisjs/core/types/transformers'
 import type { InferSharedProps } from '@adonisjs/inertia/types'
 import type AccountTransformer from '#transformers/account_transformer'
+import type AppSummaryTransformer from '#transformers/app_summary_transformer'
 import type AppTransformer from '#transformers/app_transformer'
 import type AppsTransformer from '#transformers/apps_transformer'
 import type HealthTransformer from '#transformers/health_transformer'
@@ -18,6 +19,10 @@ export namespace Data {
   export type Account = InferData<AccountTransformer>
   export namespace Account {
     export type Variants = InferVariants<AccountTransformer>
+  }
+  export type AppSummary = InferData<AppSummaryTransformer>
+  export namespace AppSummary {
+    export type Variants = InferVariants<AppSummaryTransformer>
   }
   export type App = InferData<AppTransformer>
   export namespace App {

--- a/.adonisjs/client/registry/index.ts
+++ b/.adonisjs/client/registry/index.ts
@@ -84,6 +84,12 @@ const routes = {
     tokens: [{"old":"/apps","type":0,"val":"apps","end":""}],
     types: placeholder as Registry['discover.apps']['types'],
   },
+  'discover.app': {
+    methods: ["GET","HEAD"],
+    pattern: '/apps/:rkey',
+    tokens: [{"old":"/apps/:rkey","type":0,"val":"apps","end":""},{"old":"/apps/:rkey","type":1,"val":"rkey","end":""}],
+    types: placeholder as Registry['discover.app']['types'],
+  },
   'legal.show': {
     methods: ["GET","HEAD"],
     pattern: '/legal/:document',

--- a/.adonisjs/client/registry/schema.d.ts
+++ b/.adonisjs/client/registry/schema.d.ts
@@ -163,6 +163,18 @@ export interface Registry {
       errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#controllers/discover_controller').default['apps']>>>
     }
   }
+  'discover.app': {
+    methods: ["GET","HEAD"]
+    pattern: '/apps/:rkey'
+    types: {
+      body: {}
+      paramsTuple: [ParamValue]
+      params: { rkey: ParamValue }
+      query: {}
+      response: ExtractResponse<Awaited<ReturnType<import('#controllers/discover_controller').default['app']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#controllers/discover_controller').default['app']>>>
+    }
+  }
   'legal.show': {
     methods: ["GET","HEAD"]
     pattern: '/legal/:document'

--- a/.adonisjs/client/registry/tree.d.ts
+++ b/.adonisjs/client/registry/tree.d.ts
@@ -26,6 +26,7 @@ export interface ApiDefinition {
   }
   discover: {
     apps: typeof routes['discover.apps']
+    app: typeof routes['discover.app']
   }
   legal: {
     show: typeof routes['legal.show']

--- a/.adonisjs/server/pages.d.ts
+++ b/.adonisjs/server/pages.d.ts
@@ -12,6 +12,7 @@ type ExtractProps<T> =
 
 declare module '@adonisjs/inertia/types' {
   export interface InertiaPages {
+    'apps/detail': ExtractProps<(typeof import('../../inertia/pages/apps/detail.tsx'))['default']>
     'apps/show': ExtractProps<(typeof import('../../inertia/pages/apps/show.tsx'))['default']>
     'create-account': ExtractProps<(typeof import('../../inertia/pages/create-account.tsx'))['default']>
     'dashboard/show': ExtractProps<(typeof import('../../inertia/pages/dashboard/show.tsx'))['default']>

--- a/.adonisjs/server/routes.d.ts
+++ b/.adonisjs/server/routes.d.ts
@@ -17,6 +17,7 @@ export type ScannedRoutes = {
     'account.store_acceptance': { paramsTuple?: []; params?: {} }
     'account.dismiss_welcome': { paramsTuple?: []; params?: {} }
     'discover.apps': { paramsTuple?: []; params?: {} }
+    'discover.app': { paramsTuple: [ParamValue]; params: {'rkey': ParamValue} }
     'legal.show': { paramsTuple: [ParamValue]; params: {'document': ParamValue} }
     'faq.show': { paramsTuple?: []; params?: {} }
     'health_checks.live': { paramsTuple?: []; params?: {} }
@@ -31,6 +32,7 @@ export type ScannedRoutes = {
     'explore.learn_more': { paramsTuple?: []; params?: {} }
     'account.onboarding': { paramsTuple?: []; params?: {} }
     'discover.apps': { paramsTuple?: []; params?: {} }
+    'discover.app': { paramsTuple: [ParamValue]; params: {'rkey': ParamValue} }
     'legal.show': { paramsTuple: [ParamValue]; params: {'document': ParamValue} }
     'faq.show': { paramsTuple?: []; params?: {} }
     'health_checks.live': { paramsTuple?: []; params?: {} }
@@ -45,6 +47,7 @@ export type ScannedRoutes = {
     'explore.learn_more': { paramsTuple?: []; params?: {} }
     'account.onboarding': { paramsTuple?: []; params?: {} }
     'discover.apps': { paramsTuple?: []; params?: {} }
+    'discover.app': { paramsTuple: [ParamValue]; params: {'rkey': ParamValue} }
     'legal.show': { paramsTuple: [ParamValue]; params: {'document': ParamValue} }
     'faq.show': { paramsTuple?: []; params?: {} }
     'health_checks.live': { paramsTuple?: []; params?: {} }

--- a/.changeset/twelve-numbers-shine.md
+++ b/.changeset/twelve-numbers-shine.md
@@ -1,0 +1,5 @@
+---
+'eurosky-portal': minor
+---
+
+Add app detail page

--- a/app/controllers/dashboard_controller.ts
+++ b/app/controllers/dashboard_controller.ts
@@ -1,6 +1,7 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import cache from '@adonisjs/cache/services/main'
 import { AtStoreService } from '#services/atstore_service'
+import AppSummaryTransformer from '#transformers/app_summary_transformer'
 import ProfileTransformer from '#transformers/profile_transformer'
 
 export default class DashboardController {
@@ -26,7 +27,7 @@ export default class DashboardController {
       showWelcomeMessage: !account.welcomeDismissed,
       profile: profile ? ProfileTransformer.transform(profile) : undefined,
       // Hard cap at 3.
-      apps: apps.slice(0, 3),
+      apps: AppSummaryTransformer.transform(apps.slice(0, 3)),
     })
   }
 }

--- a/app/controllers/discover_controller.ts
+++ b/app/controllers/discover_controller.ts
@@ -1,6 +1,7 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import { AtStoreService } from '#services/atstore_service'
 import AppsTransformer from '#transformers/apps_transformer'
+import AppTransformer from '#transformers/app_transformer'
 
 export default class DiscoverController {
   async apps({ inertia }: HttpContext) {
@@ -8,5 +9,16 @@ export default class DiscoverController {
     const apps = await atstore.getApps()
 
     return inertia.render('apps/show', new AppsTransformer({ apps }).toObject())
+  }
+
+  async app({ inertia, params, response }: HttpContext) {
+    const atstore = new AtStoreService()
+    const app = await atstore.getApp(params.rkey)
+
+    if (!app) {
+      return response.notFound()
+    }
+
+    return inertia.render('apps/detail', { app: AppTransformer.transform(app) })
   }
 }

--- a/app/services/atstore_service.ts
+++ b/app/services/atstore_service.ts
@@ -3,7 +3,7 @@ import app from '@adonisjs/core/services/app'
 import cache from '@adonisjs/cache/services/main'
 import logger from '@adonisjs/core/services/logger'
 import { xrpcSafe } from '@atproto/lex'
-import { asAtUriString } from '@atproto/syntax'
+import { AtUri, asAtUriString } from '@atproto/syntax'
 import type { Infer } from '@vinejs/vine/types'
 import vine from '@vinejs/vine'
 import * as lexicon from '#lexicons'
@@ -30,7 +30,15 @@ interface AtStoreListingDetail {
  */
 type AtStoreListing = Pick<
   ListingCardGet,
-  'iconUrl' | 'name' | 'rating' | 'reviewCount' | 'tagline'
+  | 'appTags'
+  | 'categorySlug'
+  | 'description'
+  | 'heroImageUrl'
+  | 'iconUrl'
+  | 'name'
+  | 'rating'
+  | 'reviewCount'
+  | 'tagline'
 >
 
 /**
@@ -103,6 +111,16 @@ export class AtStoreService {
   }
 
   /**
+   * Get an app by record key.
+   */
+  async getApp(rkey: string): Promise<App | undefined> {
+    const local = await this.#getLocalApps()
+    const localApp = local.find((a) => new AtUri(a.atUri).rkey === rkey)
+    if (!localApp) return
+    return this.#hydrate(localApp)
+  }
+
+  /**
    * Fetch details from `atstore.fyi`.
    *
    * @param atUri
@@ -122,8 +140,31 @@ export class AtStoreService {
 
     // Only pick what’s wanted.
     const { externalUrl, listing } = result.body
-    const { iconUrl, name, rating, reviewCount, tagline } = listing
-    return { externalUrl, listing: { iconUrl, name, rating, reviewCount, tagline } }
+    const {
+      appTags,
+      categorySlug,
+      description,
+      heroImageUrl,
+      iconUrl,
+      name,
+      rating,
+      reviewCount,
+      tagline,
+    } = listing
+    return {
+      externalUrl,
+      listing: {
+        appTags,
+        categorySlug,
+        description,
+        heroImageUrl,
+        iconUrl,
+        name,
+        rating,
+        reviewCount,
+        tagline,
+      },
+    }
   }
 
   /**

--- a/app/transformers/app_summary_transformer.ts
+++ b/app/transformers/app_summary_transformer.ts
@@ -1,0 +1,20 @@
+import type { App } from '#services/atstore_service'
+import { BaseTransformer } from '@adonisjs/core/transformers'
+import { AtUri } from '@atproto/syntax'
+
+export default class AppSummaryTransformer extends BaseTransformer<App> {
+  toObject() {
+    const rkey = new AtUri(this.resource.atUri).rkey
+    return {
+      ...this.pick(this.resource, ['atUri', 'madeInEurope']),
+      listing: this.pick(this.resource.listing, [
+        'iconUrl',
+        'name',
+        'rating',
+        'reviewCount',
+        'tagline',
+      ]),
+      rkey,
+    }
+  }
+}

--- a/app/transformers/app_transformer.ts
+++ b/app/transformers/app_transformer.ts
@@ -1,8 +1,13 @@
 import type { App } from '#services/atstore_service'
 import { BaseTransformer } from '@adonisjs/core/transformers'
+import { AtUri } from '@atproto/syntax'
 
 export default class AppTransformer extends BaseTransformer<App> {
   toObject() {
-    return this.pick(this.resource, ['atUri', 'externalUrl', 'listing', 'madeInEurope'])
+    const rkey = new AtUri(this.resource.atUri).rkey
+    return {
+      ...this.pick(this.resource, ['atUri', 'externalUrl', 'listing', 'madeInEurope']),
+      rkey,
+    }
   }
 }

--- a/app/transformers/apps_transformer.ts
+++ b/app/transformers/apps_transformer.ts
@@ -1,6 +1,6 @@
 import { BaseTransformer } from '@adonisjs/core/transformers'
 import type { App } from '#services/atstore_service'
-import AppTransformer from '#transformers/app_transformer'
+import AppSummaryTransformer from '#transformers/app_summary_transformer'
 
 export default class AppsTransformer extends BaseTransformer<{
   apps: ReadonlyArray<App>
@@ -28,7 +28,7 @@ export default class AppsTransformer extends BaseTransformer<{
       sections: sections.map(({ category, apps }) => ({
         apps: [...apps]
           .sort((a, b) => a.listing.name.localeCompare(b.listing.name))
-          .map((app) => new AppTransformer(app).toObject()),
+          .map((app) => new AppSummaryTransformer(app).toObject()),
         category,
       })),
     }

--- a/inertia/components/App.tsx
+++ b/inertia/components/App.tsx
@@ -3,16 +3,18 @@ import { Avatar } from '~/lib/avatar'
 import { Badge } from '~/lib/badge'
 import { ClickableCard } from '~/lib/card'
 import { Heading } from '~/lib/heading'
+import { Link } from '~/lib/link'
 import { Text } from '~/lib/text'
-import { StarIcon } from '@heroicons/react/24/solid'
+import { Rating } from './Rating'
 
-export function App({ app }: { app: Data.App }) {
+export function App({ app }: { app: Data.AppSummary }) {
   return (
     <li className="col-span-1 flex rounded-md shadow-xs dark:shadow-none">
       <ClickableCard
-        href={app.externalUrl}
-        target="_blank"
-        className="w-full focus:outline-hidden p-4 flex flex-col space-between gap-4"
+        as={Link}
+        className="w-full text-left focus:outline-hidden p-4 flex flex-col space-between gap-4"
+        route="discover.app"
+        routeParams={{ rkey: app.rkey }}
       >
         <div className="flex flex-row grow flex-1 gap-4">
           <div className="flex flex-col">
@@ -51,37 +53,5 @@ export function App({ app }: { app: Data.App }) {
         </div>
       </ClickableCard>
     </li>
-  )
-}
-
-/**
- * @param properties
- *   Properties.
- * @param properties.value
- *   Value between `0` and `5` (both including).
- * @returns {Element}
- *   Result.
- */
-function Rating(properties: { value: number }): React.JSX.Element {
-  const { value } = properties
-  const rounded = Math.round(value * 2) / 2
-  const stars = Math.floor(rounded)
-
-  return (
-    <span
-      aria-label={value + ' out of 5'}
-      className="flex items-center"
-      role="img"
-      title={value + ' out of 5'}
-    >
-      {Array.from({ length: stars }, (_, index) => (
-        <StarIcon className="size-3.5" key={index} />
-      ))}
-      {rounded - stars === 0.5 && (
-        <span className="size-3.5" style={{ marginLeft: '2px', marginTop: '-4px' }}>
-          ½
-        </span>
-      )}
-    </span>
   )
 }

--- a/inertia/components/AppGrid.tsx
+++ b/inertia/components/AppGrid.tsx
@@ -1,7 +1,7 @@
 import { Data } from '@generated/data'
 import { App } from '~/components/App'
 
-export function AppGrid({ apps }: { apps: Data.App[] }) {
+export function AppGrid({ apps }: { apps: Data.AppSummary[] }) {
   return (
     <ul
       role="list"

--- a/inertia/components/Rating.tsx
+++ b/inertia/components/Rating.tsx
@@ -1,0 +1,33 @@
+import { StarIcon } from '@heroicons/react/24/solid'
+
+/**
+ * @param properties
+ *   Properties.
+ * @param properties.value
+ *   Value between `0` and `5` (both including).
+ * @returns {Element}
+ *   Result.
+ */
+export function Rating(properties: { value: number }): React.JSX.Element {
+  const { value } = properties
+  const rounded = Math.round(value * 2) / 2
+  const stars = Math.floor(rounded)
+
+  return (
+    <span
+      aria-label={value + ' out of 5'}
+      className="flex items-center"
+      role="img"
+      title={value + ' out of 5'}
+    >
+      {Array.from({ length: stars }, (_, index) => (
+        <StarIcon className="size-3.5" key={index} />
+      ))}
+      {rounded - stars === 0.5 && (
+        <span className="size-3.5" style={{ marginLeft: '2px', marginTop: '-4px' }}>
+          ½
+        </span>
+      )}
+    </span>
+  )
+}

--- a/inertia/components/layouts/authenticated.tsx
+++ b/inertia/components/layouts/authenticated.tsx
@@ -82,7 +82,7 @@ export function AuthenticatedLayout(props: { children: ReactElement<Data.SharedP
                 </SidebarSection>
                 <SidebarHeading className="mt-10 font-bold">Discover</SidebarHeading>
                 <SidebarSection>
-                  <SidebarItem href="/apps" current={url == '/apps'}>
+                  <SidebarItem href="/apps" current={url.startsWith('/apps')}>
                     <GlobeAltIcon />
                     <SidebarLabel>Applications</SidebarLabel>
                   </SidebarItem>

--- a/inertia/lib/card.tsx
+++ b/inertia/lib/card.tsx
@@ -2,12 +2,12 @@ import clsx from 'clsx'
 import { JSXElementConstructor, createElement } from 'react'
 export type ReactTag = keyof React.JSX.IntrinsicElements | JSXElementConstructor<any>
 
-export default function Card<TTag extends ReactTag = 'div'>({
+export default function Card<As extends ReactTag = 'div'>({
   className,
   as: asElement,
   children,
   ...props
-}: React.ComponentPropsWithoutRef<TTag> & { as?: TTag }) {
+}: React.ComponentPropsWithoutRef<As> & { as?: As }) {
   return createElement(
     asElement ?? 'div',
     {
@@ -21,17 +21,22 @@ export default function Card<TTag extends ReactTag = 'div'>({
   )
 }
 
-export function ClickableCard({ className, children, ...props }: React.ComponentPropsWithRef<'a'>) {
-  return (
-    <a
-      {...props}
-      className={clsx(
+export function ClickableCard<As extends ReactTag = 'a'>({
+  className,
+  as: asElement,
+  children,
+  ...props
+}: React.ComponentPropsWithoutRef<As> & { as?: As; className?: string }) {
+  return createElement(
+    asElement ?? 'a',
+    {
+      className: clsx(
         className,
         'overflow-hidden rounded-lg bg-white shadow-sm dark:bg-slate-800/20 dark:shadow-none dark:outline dark:-outline-offset-1 dark:outline-white/10',
         'focus-visible:outline-2 focus-visible:outline-solid! focus-visible:outline-offset-2 focus-visible:outline-blue-600 hover:-outline-offset-1 border border-neutral-300/50 hover:border-neutral-300/70 dark:border-slate-800 dark:hover:border-slate-700 dark:hover:bg-slate-800/50 hover:shadow-lg'
-      )}
-    >
-      {children}
-    </a>
+      ),
+      ...props,
+    },
+    children
   )
 }

--- a/inertia/pages/apps/detail.tsx
+++ b/inertia/pages/apps/detail.tsx
@@ -1,0 +1,129 @@
+import { useMemo } from 'react'
+import { Data } from '@generated/data'
+import { ChevronLeftIcon } from '@heroicons/react/20/solid'
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/solid'
+import { Head } from '@inertiajs/react'
+import { micromark } from 'micromark'
+import { Rating } from '~/components/Rating'
+import { Avatar } from '~/lib/avatar'
+import { Badge } from '~/lib/badge'
+import Card from '~/lib/card'
+import { Heading } from '~/lib/heading'
+import { Link } from '~/lib/link'
+import { Text } from '~/lib/text'
+import { InertiaProps } from '~/types'
+
+export default function AppDetailPage({ app }: InertiaProps<{ app: Data.App }>) {
+  const { externalUrl, listing, madeInEurope } = app
+  const {
+    appTags,
+    categorySlug,
+    description,
+    heroImageUrl,
+    iconUrl,
+    name,
+    rating,
+    reviewCount,
+    tagline,
+  } = listing
+  const descriptionHtml = useMemo(
+    () => (description ? micromark(description) : undefined),
+    [description]
+  )
+  const tags = appTags.map((tag) => tag.charAt(0).toUpperCase() + tag.slice(1))
+  const categoryPrefix = 'apps/'
+  const slug = categorySlug?.startsWith(categoryPrefix)
+    ? categorySlug.slice(categoryPrefix.length)
+    : undefined
+  const reviewsUrl = slug
+    ? `https://atstore.fyi/products/${encodeURIComponent(slug)}/reviews`
+    : undefined
+
+  return (
+    <Card className="p-6 sm:p-8">
+      <Head title={name} />
+
+      <nav aria-label="Breadcrumb" className="text-sm text-zinc-500 dark:text-zinc-400 mb-8">
+        <Link className="hover:text-zinc-700 dark:hover:text-zinc-300" route="discover.apps">
+          <ChevronLeftIcon aria-hidden="true" className="size-4 inline-block" />
+          Applications
+        </Link>
+        {' / '}
+        <span aria-current="page">{name}</span>
+      </nav>
+
+      <div className="grid gap-8 sm:grid-cols-[1fr_2fr]">
+        <div className="space-y-4">
+          <div className="flex items-start gap-4">
+            <Avatar
+              className="size-16 shrink-0 bg-gray-100 outline-none! dark:bg-gray-800"
+              square
+              src={iconUrl}
+            />
+            <div className="min-w-0">
+              <Heading>{name}</Heading>
+              <Text className="mt-1">{tagline}</Text>
+            </div>
+          </div>
+
+          {madeInEurope || tags.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {madeInEurope ? <Badge color="blue">Made in Europe</Badge> : undefined}
+              {tags.map((tag) => (
+                <Badge key={tag}>{tag}</Badge>
+              ))}
+            </div>
+          ) : undefined}
+
+          {rating ? (
+            <span className="flex items-center gap-2">
+              <span className="flex items-center gap-0.5 text-sm text-amber-500">
+                <Rating value={parseFloat(rating)} />
+                <span className="ml-0.5 text-zinc-400 dark:text-zinc-500">({reviewCount})</span>
+              </span>
+              {reviewsUrl ? (
+                <a
+                  className="text-sm text-zinc-500 underline hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300"
+                  href={reviewsUrl}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  See all reviews
+                </a>
+              ) : undefined}
+            </span>
+          ) : undefined}
+
+          {descriptionHtml ? (
+            <div
+              className="markdown-document text-base/6 text-zinc-500 sm:text-sm/6 dark:text-zinc-400"
+              dangerouslySetInnerHTML={{ __html: descriptionHtml }}
+            />
+          ) : undefined}
+
+          <div className="flex flex-wrap items-center gap-3">
+            {externalUrl ? (
+              <a
+                className="inline-flex items-center justify-center rounded-lg bg-zinc-900 px-3.5 py-2.5 text-base/6 font-semibold text-white sm:px-3 sm:py-1.5 sm:text-sm/6 dark:bg-zinc-600"
+                href={externalUrl}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Explore
+                <ArrowTopRightOnSquareIcon className="ml-1 size-4" />
+              </a>
+            ) : undefined}
+          </div>
+        </div>
+
+        {heroImageUrl ? (
+          <img
+            alt=""
+            className="w-full rounded-lg outline outline-black/10 dark:outline-white/10"
+            src={heroImageUrl}
+          />
+        ) : undefined}
+      </div>
+    </Card>
+  )
+}

--- a/inertia/pages/apps/show.tsx
+++ b/inertia/pages/apps/show.tsx
@@ -6,7 +6,7 @@ import { InertiaProps } from '~/types'
 
 export default function ApplicationsPage({ sections }: InertiaProps<Data.Apps>) {
   return (
-    <Card className="py-3 px-4">
+    <Card className="p-6 sm:p-8">
       <Head title="Applications" />
       <h2 className="mt-2 mb-4 text-lg/8 sm:text-3xl/8 font-semibold text-gray-900 dark:text-gray-200">
         Applications

--- a/inertia/pages/dashboard/show.tsx
+++ b/inertia/pages/dashboard/show.tsx
@@ -19,7 +19,7 @@ export default function Dashboard({
 }: InertiaProps<{
   showWelcomeMessage: boolean
   profile: Data.Profile | undefined
-  apps: Data.App[]
+  apps: Data.AppSummary[]
 }>) {
   const user = useAuth()
   const router = useRouter()

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "edge-markdown": "^1.10.1",
     "edge.js": "^6.5.0",
     "luxon": "^3.7.2",
+    "micromark": "^4.0.2",
     "motion": "^12.38.0",
     "proxy-addr": "^2.0.7",
     "react": "^19.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       luxon:
         specifier: ^3.7.2
         version: 3.7.2
+      micromark:
+        specifier: ^4.0.2
+        version: 4.0.2
       motion:
         specifier: ^12.38.0
         version: 12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -32,6 +32,7 @@ router
   .use([middleware.auth(), middleware.legalRoadblock()])
 
 router.get('/apps', [controllers.Discover, 'apps'])
+router.get('/apps/:rkey', [controllers.Discover, 'app'])
 router.get('/legal/:document', [controllers.Legal, 'show'])
 router.get('/faq', [controllers.Faq, 'show'])
 


### PR DESCRIPTION
This adds an app detail page, closing EUR-111.

This uses a full page instead of a modal primarily to allow more clear routing:

* When I tried modals, I found myself wanting to navigate through them as if it was a carousel
* I imagine app screenshots (or other things) on these detail pages to also turn into modals/carousels

Closes EUR-111.

Screenshots:

<img width="1648" height="1072" alt="Screenshot 2026-07-06 at 3 42 32 PM" src="https://github.com/user-attachments/assets/9f9b8e20-5c21-4fc9-a1f7-6d48e2080b07" />

<img width="1648" height="1072" alt="Screenshot 2026-07-06 at 3 43 41 PM" src="https://github.com/user-attachments/assets/aea074c1-1614-49e5-9bc1-f6eb40c4a622" />
