### PR TITLE
Add support for rich text on bsky posts

### DIFF
--- a/.adonisjs/client/registry/schema.d.ts
+++ b/.adonisjs/client/registry/schema.d.ts
@@ -134,9 +134,9 @@ export interface Registry {
       body: {}
       paramsTuple: [ParamValue, ParamValue]
       params: { collection: ParamValue; rkey: ParamValue }
-      query: {}
+      query: ExtractQueryForGet<InferInput<(typeof import('#validators/activity').activityDetailValidator)>>
       response: ExtractResponse<Awaited<ReturnType<import('#controllers/activity_controller').default['detail']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#controllers/activity_controller').default['detail']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#controllers/activity_controller').default['detail']>>> | { status: 422; response: { errors: SimpleError[] } }
     }
   }
   'account.onboarding': {

--- a/app/transformers/activity_transformer.ts
+++ b/app/transformers/activity_transformer.ts
@@ -1,6 +1,7 @@
 import { BaseTransformer } from '@adonisjs/core/transformers'
 import type * as lexicon from '#lexicons'
 import type { Activity } from '#utils/activity'
+import { annotate } from '#utils/richtext'
 
 export type ActivityDetail = ReturnType<ActivityTransformer['toObject']>
 export type AppBskyFeedLikeDetail = ReturnType<AppBskyFeedLike['toObject']>
@@ -40,7 +41,8 @@ class AppBskyFeedLike extends BaseTransformer<lexicon.app.bsky.feed.like.Main> {
 
 class AppBskyFeedPost extends BaseTransformer<lexicon.app.bsky.feed.post.Main> {
   toObject() {
-    return this.pick(this.resource, ['$type', 'text'])
+    const text = annotate(this.resource.text, this.resource.facets)
+    return { ...this.pick(this.resource, ['$type']), text }
   }
 }
 

--- a/app/utils/richtext.ts
+++ b/app/utils/richtext.ts
@@ -1,0 +1,77 @@
+import type { DidString } from '@atproto/lex'
+import * as lexicon from '#lexicons'
+
+type Facet = lexicon.app.bsky.richtext.facet.Main
+
+export type FeatureLink = {
+  type: 'link'
+  uri: string
+}
+
+export type FeatureMention = {
+  did: DidString
+  type: 'mention'
+}
+
+export type FeatureTag = {
+  tag: string
+  type: 'tag'
+}
+
+export type Feature = FeatureLink | FeatureMention | FeatureTag
+
+export type Segment = {
+  feature: Feature | undefined
+  text: string
+}
+
+/**
+ * Split text into segments using its facets.
+ *
+ * @param text
+ * @param facets
+ * @returns
+ *   Segments.
+ */
+export function annotate(text: string, facets: ReadonlyArray<Facet> | undefined): Array<Segment> {
+  const bytes = new TextEncoder().encode(text)
+  const decoder = new TextDecoder()
+  const result: Array<Segment> = []
+  const sorted = [...(facets ?? [])].sort((a, b) => a.index.byteStart - b.index.byteStart)
+
+  let cursor = 0
+
+  for (const facet of sorted) {
+    const { byteEnd, byteStart } = facet.index
+    if (byteStart < cursor || byteEnd > bytes.length || byteStart >= byteEnd) continue
+
+    const feature = toFeature(facet)
+    if (!feature) continue
+
+    const before = decoder.decode(bytes.slice(cursor, byteStart))
+    const value = decoder.decode(bytes.slice(byteStart, byteEnd))
+
+    if (before) result.push({ feature: undefined, text: before })
+    if (value) result.push({ feature, text: value })
+
+    cursor = byteEnd
+  }
+
+  const after = decoder.decode(bytes.slice(cursor))
+  if (after) result.push({ feature: undefined, text: after })
+
+  return result
+}
+
+/**
+ * Find the first known feature on a facet.
+ */
+function toFeature(facet: Facet): Feature | undefined {
+  const { link, mention, tag } = lexicon.app.bsky.richtext.facet
+
+  for (const raw of facet.features) {
+    if (link.isTypeOf(raw)) return { type: 'link', uri: raw.uri }
+    if (mention.isTypeOf(raw)) return { did: raw.did, type: 'mention' }
+    if (tag.isTypeOf(raw)) return { tag: raw.tag, type: 'tag' }
+  }
+}

--- a/inertia/components/RichText.tsx
+++ b/inertia/components/RichText.tsx
@@ -1,0 +1,18 @@
+import { Fragment } from 'react'
+import type { Segment } from '#utils/richtext'
+
+export function RichText({ text }: { text: Array<Segment> }) {
+  return (
+    <div className="whitespace-pre-wrap text-base text-zinc-900 dark:text-white">
+      {text.map(({ feature, text }, key) => {
+        return feature ? (
+          <a className="text-blue-600 dark:text-blue-400" key={key}>
+            {text}
+          </a>
+        ) : (
+          <Fragment key={key}>{text}</Fragment>
+        )
+      })}
+    </div>
+  )
+}

--- a/inertia/pages/activity/detail.tsx
+++ b/inertia/pages/activity/detail.tsx
@@ -1,6 +1,7 @@
 import { ChevronLeftIcon } from '@heroicons/react/20/solid'
 import { Head } from '@inertiajs/react'
 import type { ActivityDetail } from '#transformers/activity_transformer'
+import { RichText } from '~/components/RichText'
 import Card from '~/lib/card'
 import { Link } from '~/lib/link'
 import { Text } from '~/lib/text'
@@ -26,11 +27,7 @@ export default function ActivityDetailPage({
       title = 'Like'
       break
     case 'app.bsky.feed.post':
-      detail = (
-        <p className="whitespace-pre-wrap text-base text-zinc-900 dark:text-white">
-          {activity.text}
-        </p>
-      )
+      detail = <RichText text={activity.text} />
       title = 'Post'
       break
     case 'app.bsky.graph.follow':


### PR DESCRIPTION
This adds minimal support for rich text (“facets”) to bluesky posts.
It only colors links/mentions/tags blue, really. More can be done later.

Screenshot:

<img width="1648" height="1072" alt="Screenshot 2026-07-14 at 12 41 04 PM" src="https://github.com/user-attachments/assets/ba5c8d1d-c44d-4d7c-bf6b-8bdc4c222ff7" />
