### PR TITLE
Add support for embeds on bsky posts

### DIFF
--- a/app/controllers/activity_controller.ts
+++ b/app/controllers/activity_controller.ts
@@ -32,7 +32,7 @@ export default class ActivityController {
 
     const record = await activityService.getRecord(did, collection, rkey)
     if (!record) return response.notFound()
-    const activity = new ActivityTransformer(record).toObject()
+    const activity = new ActivityTransformer(record.value, { did, pds: record.pds }).toObject()
     return inertia.render('activity/detail', { activity })
   }
 }

--- a/app/services/activity_service.ts
+++ b/app/services/activity_service.ts
@@ -124,7 +124,7 @@ export class ActivityService {
    *   Promise that resolves when done.
    */
   async backfillCollection(did: DidString, collection: SupportedCollection): Promise<undefined> {
-    const client = await this.#clientFor(did)
+    const { client } = await this.#clientFor(did)
     await this.#syncCollection(client, did, collection, DateTime.now())
   }
 
@@ -266,18 +266,19 @@ export class ActivityService {
    * @param rkey
    *   Record key.
    * @returns
-   *   Promise that resolves to the record value.
+   *   Promise that resolves to the record value and the PDS it was fetched
+   *   from.
    */
   async getRecord(
     did: DidString,
     collection: SupportedCollection,
     rkey: string
-  ): Promise<Activity | undefined> {
+  ): Promise<{ pds: string; value: Activity } | undefined> {
     const uri = `at://${did}/${collection}/${rkey}`
     const row = await ActivityRecord.query().where('uri', uri).first()
     if (!row) return
 
-    const client = await this.#clientFor(did)
+    const { client, pds } = await this.#clientFor(did)
     let value: Activity | undefined
 
     try {
@@ -298,9 +299,12 @@ export class ActivityService {
     }
 
     // No longer parses: don’t keep stale activity around.
-    if (!value) await ActivityRecord.query().where('uri', uri).delete()
+    if (!value) {
+      await ActivityRecord.query().where('uri', uri).delete()
+      return
+    }
 
-    return value
+    return { pds, value }
   }
 
   /**
@@ -309,12 +313,12 @@ export class ActivityService {
    * @param did
    *   DID.
    * @returns
-   *   Promise that resolves to a client.
+   *   Promise that resolves to a client and the PDS it talks to.
    */
-  async #clientFor(did: DidString): Promise<Client> {
+  async #clientFor(did: DidString): Promise<{ client: Client; pds: string }> {
     const resolved = await this.#slingshot.resolveMiniDoc(did)
     if (!resolved) throw new Error(`Could not resolve PDS for \`${did}\``)
-    return new Client(resolved.pds)
+    return { client: new Client(resolved.pds), pds: resolved.pds }
   }
 
   /**
@@ -324,7 +328,7 @@ export class ActivityService {
    *   Promise that resolves when done.
    */
   async #sync(did: DidString) {
-    const client = await this.#clientFor(did)
+    const { client } = await this.#clientFor(did)
     const describeResponse = await client.xrpc(lexicon.com.atproto.repo.describeRepo.main, {
       params: { repo: did },
       signal: AbortSignal.timeout(5000),

--- a/app/services/jetstream_service.ts
+++ b/app/services/jetstream_service.ts
@@ -1,7 +1,7 @@
 import { DateTime } from 'luxon'
 import cache from '@adonisjs/cache/services/main'
 import logger from '@adonisjs/core/services/logger'
-import { type DidString, isDidString, isNsidString } from '@atproto/lex'
+import { type DidString, type LexValue, isDidString, isNsidString, lexParse } from '@atproto/lex'
 import Account from '#models/account'
 import ActivityRecord from '#models/activity_record'
 import { supportedCollections, toPreview, toValue } from '#utils/activity'
@@ -26,7 +26,7 @@ interface JetstreamCommit {
   cid?: string
   collection: string
   operation: 'create' | 'delete' | 'update'
-  record?: Record<string, unknown>
+  record?: LexValue
   rev: string
   rkey: string
 }
@@ -182,7 +182,7 @@ export class JetstreamService {
       let message: JetstreamMessage
 
       try {
-        message = JSON.parse(event.data)
+        message = lexParse(event.data) as unknown as JetstreamMessage
       } catch (err) {
         logger.warn({ err }, 'jetstream: cannot handle message')
         return
@@ -259,10 +259,16 @@ export class JetstreamService {
       return
     }
 
+    if (!record) {
+      logger.warn({ operation, uri }, 'jetstream: missing commit `record` in create/update')
+      return
+    }
+
     const activity = toValue(collection, record)
 
     // Unknown collection / invalid record.
     if (!activity) {
+      logger.warn({ collection, uri }, 'jetstream: record does not match its lexicon, dropping')
       await ActivityRecord.query().where('uri', uri).delete()
       return
     }

--- a/app/transformers/activity_transformer.ts
+++ b/app/transformers/activity_transformer.ts
@@ -1,6 +1,7 @@
 import { BaseTransformer } from '@adonisjs/core/transformers'
 import type * as lexicon from '#lexicons'
 import type { Activity } from '#utils/activity'
+import { type Context, toEmbed } from '#utils/embed'
 import { annotate } from '#utils/richtext'
 
 export type ActivityDetail = ReturnType<ActivityTransformer['toObject']>
@@ -11,6 +12,13 @@ export type IdSifaProfileLanguageDetail = ReturnType<IdSifaProfileLanguage['toOb
 export type SiteStandardDocumentDetail = ReturnType<SiteStandardDocument['toObject']>
 
 export default class ActivityTransformer extends BaseTransformer<Activity> {
+  #context: Context
+
+  constructor(resource: Activity, context: Context) {
+    super(resource)
+    this.#context = context
+  }
+
   toObject() {
     const { resource } = this
     const { $type } = resource
@@ -19,7 +27,7 @@ export default class ActivityTransformer extends BaseTransformer<Activity> {
       case 'app.bsky.feed.like':
         return new AppBskyFeedLike(resource).toObject()
       case 'app.bsky.feed.post':
-        return new AppBskyFeedPost(resource).toObject()
+        return new AppBskyFeedPost(resource, this.#context).toObject()
       case 'app.bsky.graph.follow':
         return new AppBskyGraphFollow(resource).toObject()
       case 'id.sifa.profile.language':
@@ -40,9 +48,17 @@ class AppBskyFeedLike extends BaseTransformer<lexicon.app.bsky.feed.like.Main> {
 }
 
 class AppBskyFeedPost extends BaseTransformer<lexicon.app.bsky.feed.post.Main> {
+  #context: Context
+
+  constructor(resource: lexicon.app.bsky.feed.post.Main, context: Context) {
+    super(resource)
+    this.#context = context
+  }
+
   toObject() {
+    const embed = this.resource.embed ? toEmbed(this.resource.embed, this.#context) : undefined
     const text = annotate(this.resource.text, this.resource.facets)
-    return { ...this.pick(this.resource, ['$type']), text }
+    return { ...this.pick(this.resource, ['$type']), embed, text }
   }
 }
 

--- a/app/utils/embed.ts
+++ b/app/utils/embed.ts
@@ -1,0 +1,184 @@
+import { type BlobRef, type DidString, getBlobCidString, isBlobRef } from '@atproto/lex'
+import * as lexicon from '#lexicons'
+
+type LexiconEmbed = NonNullable<lexicon.app.bsky.feed.post.Main['embed']>
+type LexiconExternal = lexicon.app.bsky.embed.external.Main
+type LexiconMedia = LexiconRecordWithMedia['media']
+type LexiconImages = lexicon.app.bsky.embed.images.Main
+type LexiconRecord = lexicon.app.bsky.embed.record.Main
+type LexiconRecordWithMedia = lexicon.app.bsky.embed.recordWithMedia.Main
+
+export type AspectRatio = {
+  height: number
+  width: number
+}
+
+export interface Context {
+  did: DidString
+  pds: string
+}
+
+export type BlobLocator = {
+  cid: string
+  did: DidString
+  pds: string
+}
+
+export type Embed = Media | EmbedRecord
+
+export type External = {
+  description: string
+  thumbnail: BlobLocator | undefined
+  title: string
+  type: 'external'
+  uri: string
+}
+
+export type Images = {
+  images: Array<Image>
+  type: 'images'
+}
+
+export type Image = {
+  alt: string
+  aspectRatio: AspectRatio | undefined
+  blob: BlobLocator
+}
+
+export type Media = External | Images | Unknown | Video
+
+export type EmbedRecord = {
+  media: Media | undefined
+  type: 'record'
+  uri: string
+}
+
+export type Unknown = {
+  type: 'unknown'
+}
+
+export type Video = {
+  type: 'video'
+}
+
+/**
+ * Turn a lexicon value into a renderable value.
+ *
+ * @param value
+ *   Value.
+ * @param context
+ *   DID + PDS.
+ * @returns
+ *   Normalized embed.
+ */
+export function toEmbed(value: LexiconEmbed, context: Context): Embed {
+  if (lexicon.app.bsky.embed.record.main.isTypeOf(value)) {
+    return recordToEmbed(value)
+  }
+
+  if (lexicon.app.bsky.embed.recordWithMedia.main.isTypeOf(value)) {
+    return recordWithMediaToEmbed(value, context)
+  }
+
+  return mediaToEmbed(value, context)
+}
+
+function externalToEmbed(value: LexiconExternal, context: Context): External {
+  return {
+    description: value.external.description,
+    thumbnail: value.external.thumb ? toBlobLocator(value.external.thumb, context) : undefined,
+    title: value.external.title,
+    type: 'external',
+    uri: value.external.uri,
+  }
+}
+
+function imagesToEmbed(value: LexiconImages, context: Context): Images {
+  return {
+    images: value.images.map((image) => toImage(image, context)),
+    type: 'images',
+  }
+}
+
+function mediaToEmbed(value: LexiconMedia, context: Context): Media {
+  if (lexicon.app.bsky.embed.external.main.isTypeOf(value)) {
+    return externalToEmbed(value, context)
+  }
+
+  if (lexicon.app.bsky.embed.images.main.isTypeOf(value)) {
+    return imagesToEmbed(value, context)
+  }
+
+  if (lexicon.app.bsky.embed.video.main.isTypeOf(value)) {
+    return videoToEmbed()
+  }
+
+  // Ducktype the shape of `app.bsky.embed.gallery` which is not yet published:
+  // <https://github.com/bluesky-social/atproto/discussions/5032>.
+  if (value.$type === 'app.bsky.embed.gallery' && 'items' in value && Array.isArray(value.items)) {
+    const items = value.items as ReadonlyArray<unknown>
+    const images: Array<Image> = []
+    for (const item of items) {
+      if (
+        item &&
+        typeof item === 'object' &&
+        'alt' in item &&
+        typeof item.alt === 'string' &&
+        'image' in item &&
+        isBlobRef(item.image)
+      ) {
+        let aspectRatio: AspectRatio | undefined
+
+        if (
+          'aspectRatio' in item &&
+          typeof item.aspectRatio === 'object' &&
+          item.aspectRatio !== null &&
+          'height' in item.aspectRatio &&
+          'width' in item.aspectRatio
+        ) {
+          const { height, width } = item.aspectRatio
+          if (typeof height === 'number' && typeof width === 'number') {
+            aspectRatio = { height, width }
+          }
+        }
+
+        images.push(toImage({ alt: item.alt, aspectRatio, image: item.image }, context))
+      }
+    }
+    return { images, type: 'images' }
+  }
+
+  return unknownToEmbed()
+}
+
+function recordToEmbed(value: LexiconRecord): EmbedRecord {
+  return { media: undefined, type: 'record', uri: value.record.uri }
+}
+
+function recordWithMediaToEmbed(value: LexiconRecordWithMedia, context: Context): EmbedRecord {
+  const media = mediaToEmbed(value.media, context)
+  return { media, type: 'record', uri: value.record.record.uri }
+}
+
+function toBlobLocator(blob: BlobRef, context: Context): BlobLocator {
+  return { cid: getBlobCidString(blob), did: context.did, pds: context.pds }
+}
+
+function toImage(
+  value: { alt: string; aspectRatio?: AspectRatio | undefined; image: BlobRef },
+  context: Context
+): Image {
+  return {
+    alt: value.alt,
+    aspectRatio: value.aspectRatio,
+    blob: toBlobLocator(value.image, context),
+  }
+}
+
+function unknownToEmbed(): Unknown {
+  return { type: 'unknown' }
+}
+
+function videoToEmbed(): Video {
+  return { type: 'video' }
+}

--- a/inertia/components/BlobImage.tsx
+++ b/inertia/components/BlobImage.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react'
+import type { BlobLocator } from '#utils/embed'
+import { toBlobCdnUrl, toBlobPdsUrl } from '~/utils/blob'
+
+export function BlobImage({
+  alt,
+  blob,
+  className,
+}: {
+  alt: string
+  blob: BlobLocator
+  className?: string
+}) {
+  const cdnUrl = toBlobCdnUrl(blob)
+  const [src, setSrc] = useState(cdnUrl)
+
+  return (
+    <img
+      alt={alt}
+      className={className}
+      onError={() => setSrc((current) => (current === cdnUrl ? toBlobPdsUrl(blob) : current))}
+      src={src}
+    />
+  )
+}

--- a/inertia/components/Embed.tsx
+++ b/inertia/components/Embed.tsx
@@ -1,0 +1,27 @@
+import { NoSymbolIcon } from '@heroicons/react/24/outline'
+import type { Embed } from '#utils/embed'
+import { EmbedExternal } from '~/components/embed/EmbedExternal'
+import { EmbedImages } from '~/components/embed/EmbedImages'
+import { EmbedRecord } from '~/components/embed/EmbedRecord'
+
+export function Embed({ embed }: { embed: Embed }) {
+  switch (embed.type) {
+    case 'external':
+      return <EmbedExternal embed={embed} />
+    case 'images':
+      return <EmbedImages embed={embed} />
+    case 'record':
+      return (
+        <EmbedRecord embed={embed}>
+          {embed.media ? <Embed embed={embed.media} /> : undefined}
+        </EmbedRecord>
+      )
+    default:
+      return (
+        <div className="flex items-center gap-3 rounded-lg border border-dashed border-zinc-300 p-4 text-zinc-500 dark:border-zinc-600 dark:text-zinc-400">
+          <NoSymbolIcon aria-hidden="true" className="size-6 shrink-0" />
+          <p className="text-sm">Could not display this embed</p>
+        </div>
+      )
+  }
+}

--- a/inertia/components/embed/EmbedExternal.tsx
+++ b/inertia/components/embed/EmbedExternal.tsx
@@ -1,0 +1,24 @@
+import type { External } from '#utils/embed'
+import { BlobImage } from '~/components/BlobImage'
+
+export function EmbedExternal({ embed }: { embed: External }) {
+  // Note: not actually linking.
+  return (
+    <div className="grid gap-2 grid-cols-2 xl:grid-cols-3">
+      <div className="block w-full overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-700">
+        {embed.thumbnail ? (
+          <BlobImage alt="" blob={embed.thumbnail} className="h-40 w-full object-cover" />
+        ) : undefined}
+        <div className="p-3">
+          <p className="text-sm font-medium text-zinc-900 dark:text-white">{embed.title}</p>
+          {embed.description ? (
+            <p className="mt-1 line-clamp-2 text-sm text-zinc-500 dark:text-zinc-400">
+              {embed.description}
+            </p>
+          ) : undefined}
+          <p className="mt-1 truncate text-xs text-zinc-400 dark:text-zinc-500">{embed.uri}</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/inertia/components/embed/EmbedImages.tsx
+++ b/inertia/components/embed/EmbedImages.tsx
@@ -1,0 +1,32 @@
+import type { Images } from '#utils/embed'
+import { BlobImage } from '~/components/BlobImage'
+
+export function EmbedImages({ embed }: { embed: Images }) {
+  if (embed.images.length > 4) {
+    return (
+      <div className="-mx-6 px-6 flex gap-2 overflow-x-auto sm:-mx-8 sm:px-8">
+        {embed.images.map((image, key) => (
+          <BlobImage
+            alt={image.alt}
+            blob={image.blob}
+            className="aspect-square w-[45%] shrink-0 rounded-lg object-cover sm:w-[30%]"
+            key={key}
+          />
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid gap-2 grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      {embed.images.map((image, key) => (
+        <BlobImage
+          alt={image.alt}
+          blob={image.blob}
+          className="aspect-square w-full rounded-lg object-cover"
+          key={key}
+        />
+      ))}
+    </div>
+  )
+}

--- a/inertia/components/embed/EmbedRecord.tsx
+++ b/inertia/components/embed/EmbedRecord.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from 'react'
+import type { EmbedRecord } from '#utils/embed'
+
+export function EmbedRecord({ children, embed }: { children: ReactNode; embed: EmbedRecord }) {
+  return (
+    <div className="space-y-3">
+      {children}
+      <div className="rounded-lg border border-zinc-200 p-3 dark:border-zinc-700">
+        {/* Just display the `at://` uri for now. */}
+        <p className="font-mono text-xs break-all text-zinc-500 dark:text-zinc-400">{embed.uri}</p>
+      </div>
+    </div>
+  )
+}

--- a/inertia/pages/activity/detail.tsx
+++ b/inertia/pages/activity/detail.tsx
@@ -1,6 +1,7 @@
 import { ChevronLeftIcon } from '@heroicons/react/20/solid'
 import { Head } from '@inertiajs/react'
 import type { ActivityDetail } from '#transformers/activity_transformer'
+import { Embed } from '~/components/Embed'
 import { RichText } from '~/components/RichText'
 import Card from '~/lib/card'
 import { Link } from '~/lib/link'
@@ -27,7 +28,12 @@ export default function ActivityDetailPage({
       title = 'Like'
       break
     case 'app.bsky.feed.post':
-      detail = <RichText text={activity.text} />
+      detail = (
+        <>
+          <RichText text={activity.text} />
+          {activity.embed ? <Embed embed={activity.embed} /> : undefined}
+        </>
+      )
       title = 'Post'
       break
     case 'app.bsky.graph.follow':

--- a/inertia/utils/blob.ts
+++ b/inertia/utils/blob.ts
@@ -1,0 +1,24 @@
+import type { BlobLocator } from '#utils/embed'
+
+/**
+ * URL to blob on Bluesky CDN.
+ *
+ * @returns
+ *   URL to blob.
+ */
+export function toBlobCdnUrl(blob: BlobLocator): string {
+  return `https://cdn.bsky.app/img/feed_thumbnail/plain/${blob.did}/${blob.cid}@jpeg`
+}
+
+/**
+ * URL to blob on the PDS that hosts it.
+ *
+ * @returns
+ *   URL to blob.
+ */
+export function toBlobPdsUrl(blob: BlobLocator): string {
+  const url = new URL('/xrpc/com.atproto.sync.getBlob', blob.pds)
+  url.searchParams.set('cid', blob.cid)
+  url.searchParams.set('did', blob.did)
+  return url.toString()
+}


### PR DESCRIPTION
Shows cards for URLs (`app.bsky.embed.external`), images (`app.bsky.embed.images`), and reposts/quotes (`app.bsky.embed.record`). Also supports the future `app.bsky.embed.gallery` as images. Renders unknown embeds with a placeholder and uses that for videos for now.

Uses `cdn.bsky.app` if available to show images, otherwise falls back to the PDS.

Additionally fixes a bug in blobs on the jetstream.

Related-to EUR-131.

Screenshots:

<img width="1648" height="1072" alt="Screenshot 2026-07-14 at 1 10 39 PM" src="https://github.com/user-attachments/assets/a3656ff3-f6b1-4ef4-9cd7-13d040683777" />
<img width="1648" height="1072" alt="Screenshot 2026-07-14 at 1 10 47 PM" src="https://github.com/user-attachments/assets/2104520c-2aad-4f8a-9673-ebb259f0ba50" />
