### PR TITLE
Add “open with” launcher to activity detail

### DIFF
--- a/.changeset/hungry-cows-refuse.md
+++ b/.changeset/hungry-cows-refuse.md
@@ -1,0 +1,5 @@
+---
+'eurosky-portal': minor
+---
+
+Add social post (mu)

--- a/app/controllers/activity_controller.ts
+++ b/app/controllers/activity_controller.ts
@@ -32,7 +32,8 @@ export default class ActivityController {
 
     const record = await activityService.getRecord(did, collection, rkey)
     if (!record) return response.notFound()
-    const activity = new ActivityTransformer(record.value, { did, pds: record.pds }).toObject()
+    const { pds, uri, value } = record
+    const activity = new ActivityTransformer(value, { did, pds, uri }).toObject()
     return inertia.render('activity/detail', { activity })
   }
 }

--- a/app/services/activity_service.ts
+++ b/app/services/activity_service.ts
@@ -1,6 +1,6 @@
 import { DateTime } from 'luxon'
 import logger from '@adonisjs/core/services/logger'
-import { Client, type DidString, XrpcResponseError } from '@atproto/lex'
+import { type AtUriString, Client, type DidString, XrpcResponseError } from '@atproto/lex'
 import * as lexicon from '#lexicons'
 import Account from '#models/account'
 import ActivityRecord from '#models/activity_record'
@@ -273,8 +273,8 @@ export class ActivityService {
     did: DidString,
     collection: SupportedCollection,
     rkey: string
-  ): Promise<{ pds: string; value: Activity } | undefined> {
-    const uri = `at://${did}/${collection}/${rkey}`
+  ): Promise<{ pds: string; uri: AtUriString; value: Activity } | undefined> {
+    const uri: AtUriString = `at://${did}/${collection}/${rkey}`
     const row = await ActivityRecord.query().where('uri', uri).first()
     if (!row) return
 
@@ -287,12 +287,12 @@ export class ActivityService {
         signal: AbortSignal.timeout(10_000),
       })
       value = toValue(collection, response.body.value)
-    } catch (error) {
+    } catch (err) {
       // Actually gone upstream: don’t keep stale activity around.
-      if (error instanceof XrpcResponseError && error.error === 'RecordNotFound') {
+      if (err instanceof XrpcResponseError && err.error === 'RecordNotFound') {
         await ActivityRecord.query().where('uri', uri).delete()
       } else {
-        logger.warn({ collection, did, error, rkey }, 'activity: cannot fetch record')
+        logger.warn({ collection, did, err, rkey }, 'activity: cannot fetch record')
       }
 
       return
@@ -304,7 +304,7 @@ export class ActivityService {
       return
     }
 
-    return { pds, value }
+    return { pds, uri, value }
   }
 
   /**

--- a/app/transformers/activity_transformer.ts
+++ b/app/transformers/activity_transformer.ts
@@ -1,4 +1,5 @@
 import { BaseTransformer } from '@adonisjs/core/transformers'
+import type { AtUriString } from '@atproto/lex'
 import type * as lexicon from '#lexicons'
 import type { Activity } from '#utils/activity'
 import { type Context, toEmbed } from '#utils/embed'
@@ -11,10 +12,17 @@ export type AppBskyGraphFollowDetail = ReturnType<AppBskyGraphFollow['toObject']
 export type IdSifaProfileLanguageDetail = ReturnType<IdSifaProfileLanguage['toObject']>
 export type SiteStandardDocumentDetail = ReturnType<SiteStandardDocument['toObject']>
 
-export default class ActivityTransformer extends BaseTransformer<Activity> {
-  #context: Context
+export interface RecordContext extends Context {
+  /**
+   * `at://` URI of the record itself.
+   */
+  uri: AtUriString
+}
 
-  constructor(resource: Activity, context: Context) {
+export default class ActivityTransformer extends BaseTransformer<Activity> {
+  #context: RecordContext
+
+  constructor(resource: Activity, context: RecordContext) {
     super(resource)
     this.#context = context
   }
@@ -33,7 +41,7 @@ export default class ActivityTransformer extends BaseTransformer<Activity> {
       case 'id.sifa.profile.language':
         return new IdSifaProfileLanguage(resource).toObject()
       case 'site.standard.document':
-        return new SiteStandardDocument(resource).toObject()
+        return new SiteStandardDocument(resource, this.#context).toObject()
       default:
         throw new Error(`Unsupported activity type: ${$type}`)
     }
@@ -42,29 +50,31 @@ export default class ActivityTransformer extends BaseTransformer<Activity> {
 
 class AppBskyFeedLike extends BaseTransformer<lexicon.app.bsky.feed.like.Main> {
   toObject() {
-    const subject = this.pick(this.resource.subject, ['$type', 'uri'])
-    return { ...this.pick(this.resource, ['$type']), subject }
+    return { ...this.pick(this.resource, ['$type']), openUri: this.resource.subject.uri }
   }
 }
 
 class AppBskyFeedPost extends BaseTransformer<lexicon.app.bsky.feed.post.Main> {
-  #context: Context
+  #context: RecordContext
 
-  constructor(resource: lexicon.app.bsky.feed.post.Main, context: Context) {
+  constructor(resource: lexicon.app.bsky.feed.post.Main, context: RecordContext) {
     super(resource)
     this.#context = context
   }
 
   toObject() {
     const embed = this.resource.embed ? toEmbed(this.resource.embed, this.#context) : undefined
+    const openUri = this.#context.uri
+    const replyUri = this.resource.reply ? this.resource.reply.parent.uri : undefined
     const text = annotate(this.resource.text, this.resource.facets)
-    return { ...this.pick(this.resource, ['$type']), embed, text }
+    return { ...this.pick(this.resource, ['$type']), embed, openUri, replyUri, text }
   }
 }
 
 class AppBskyGraphFollow extends BaseTransformer<lexicon.app.bsky.graph.follow.Main> {
   toObject() {
-    return this.pick(this.resource, ['$type', 'subject'])
+    const openUri: AtUriString = `at://${this.resource.subject}`
+    return { ...this.pick(this.resource, ['$type']), openUri }
   }
 }
 
@@ -75,7 +85,17 @@ class IdSifaProfileLanguage extends BaseTransformer<lexicon.id.sifa.profile.lang
 }
 
 class SiteStandardDocument extends BaseTransformer<lexicon.site.standard.document.Main> {
+  #context: RecordContext
+
+  constructor(resource: lexicon.site.standard.document.Main, context: RecordContext) {
+    super(resource)
+    this.#context = context
+  }
+
   toObject() {
-    return this.pick(this.resource, ['$type', 'description', 'site', 'tags', 'title'])
+    return {
+      ...this.pick(this.resource, ['$type', 'description', 'site', 'tags', 'title']),
+      openUri: this.#context.uri,
+    }
   }
 }

--- a/inertia/components/Embed.tsx
+++ b/inertia/components/Embed.tsx
@@ -11,11 +11,7 @@ export function Embed({ embed }: { embed: Embed }) {
     case 'images':
       return <EmbedImages embed={embed} />
     case 'record':
-      return (
-        <EmbedRecord embed={embed}>
-          {embed.media ? <Embed embed={embed.media} /> : undefined}
-        </EmbedRecord>
-      )
+      return <EmbedRecord embed={embed} />
     default:
       return (
         <div className="flex items-center gap-3 rounded-lg border border-dashed border-zinc-300 p-4 text-zinc-500 dark:border-zinc-600 dark:text-zinc-400">

--- a/inertia/components/OpenWith.tsx
+++ b/inertia/components/OpenWith.tsx
@@ -1,0 +1,63 @@
+import type { AtUriString } from '@atproto/lex'
+import { CheckIcon, ChevronDownIcon } from '@heroicons/react/16/solid'
+import clsx from 'clsx'
+import { useState } from 'react'
+import { TouchTarget, styles as buttonStyles } from '~/lib/button'
+import { Dropdown, DropdownButton, DropdownItem, DropdownMenu } from '~/lib/dropdown'
+import { find, prefer, sort } from '~/utils/apps'
+
+interface Properties {
+  uri: AtUriString
+}
+
+export function OpenWith({ uri }: Properties) {
+  // Only used to force a render and sort again after marking an app as
+  // preferred.
+  const [, update] = useState(0)
+  const apps = sort(find(uri))
+
+  if (!apps.length) return
+
+  const [preferredName, preferredUrl] = apps[0]
+
+  return (
+    <span className="inline-flex">
+      <a
+        className={clsx(
+          buttonStyles.base,
+          buttonStyles.outline,
+          '-mr-px rounded-r-none pr-3.5 sm:pr-3'
+        )}
+        href={preferredUrl}
+        rel="noreferrer"
+        target="_blank"
+      >
+        <TouchTarget>Open with {preferredName}</TouchTarget>
+      </a>
+      <Dropdown>
+        <DropdownButton className="rounded-l-none px-2 sm:px-1.5" outline>
+          <ChevronDownIcon aria-hidden="true" className="size-4" />
+          <span className="sr-only">Choose an app to open this with</span>
+        </DropdownButton>
+        <DropdownMenu anchor="bottom end">
+          {apps.map(([name]) => (
+            <DropdownItem
+              key={name}
+              onClick={() => {
+                prefer(name)
+                update((value) => value + 1)
+              }}
+            >
+              <span className="col-span-full flex w-full items-center justify-between gap-2">
+                {name}
+                {name === preferredName ? (
+                  <CheckIcon aria-hidden="true" className="size-4 shrink-0" />
+                ) : undefined}
+              </span>
+            </DropdownItem>
+          ))}
+        </DropdownMenu>
+      </Dropdown>
+    </span>
+  )
+}

--- a/inertia/components/RichText.tsx
+++ b/inertia/components/RichText.tsx
@@ -3,12 +3,12 @@ import type { Segment } from '#utils/richtext'
 
 export function RichText({ text }: { text: Array<Segment> }) {
   return (
-    <div className="whitespace-pre-wrap text-base text-zinc-900 dark:text-white">
+    <div className="p-4 whitespace-pre-wrap text-base text-zinc-900 dark:text-white">
       {text.map(({ feature, text }, key) => {
         return feature ? (
-          <a className="text-blue-600 dark:text-blue-400" key={key}>
+          <span className="text-blue-600 dark:text-blue-400" key={key}>
             {text}
-          </a>
+          </span>
         ) : (
           <Fragment key={key}>{text}</Fragment>
         )

--- a/inertia/components/embed/EmbedRecord.tsx
+++ b/inertia/components/embed/EmbedRecord.tsx
@@ -1,14 +1,15 @@
-import type { ReactNode } from 'react'
+import { ChatBubbleLeftIcon } from '@heroicons/react/20/solid'
 import type { EmbedRecord } from '#utils/embed'
+import { Embed } from '../Embed'
 
-export function EmbedRecord({ children, embed }: { children: ReactNode; embed: EmbedRecord }) {
+export function EmbedRecord({ embed }: { embed: EmbedRecord }) {
   return (
     <div className="space-y-3">
-      {children}
-      <div className="rounded-lg border border-zinc-200 p-3 dark:border-zinc-700">
-        {/* Just display the `at://` uri for now. */}
-        <p className="font-mono text-xs break-all text-zinc-500 dark:text-zinc-400">{embed.uri}</p>
+      <div className="flex items-center gap-3 rounded-lg border border-dashed border-zinc-300 p-4 text-sm text-zinc-500 dark:border-zinc-600 dark:text-zinc-400">
+        <ChatBubbleLeftIcon aria-hidden="true" className="size-3.5 shrink-0" />
+        Quoting a record
       </div>
+      {embed.media ? <Embed embed={embed.media} /> : null}
     </div>
   )
 }

--- a/inertia/lib/button.tsx
+++ b/inertia/lib/button.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef } from 'react'
 import { Link } from './link'
 import type { LinkProps } from '@adonisjs/inertia/react'
 
-const styles = {
+export const styles = {
   base: [
     // Base
     'relative isolate inline-flex items-baseline justify-center gap-x-2 rounded-lg border text-base/6 font-semibold',

--- a/inertia/pages/activity/detail.tsx
+++ b/inertia/pages/activity/detail.tsx
@@ -1,7 +1,15 @@
-import { ChevronLeftIcon } from '@heroicons/react/20/solid'
+import {
+  ArrowUturnLeftIcon,
+  ChevronLeftIcon,
+  HeartIcon,
+  LanguageIcon,
+  UserPlusIcon,
+} from '@heroicons/react/20/solid'
 import { Head } from '@inertiajs/react'
+import type { ReactNode } from 'react'
 import type { ActivityDetail } from '#transformers/activity_transformer'
 import { Embed } from '~/components/Embed'
+import { OpenWith } from '~/components/OpenWith'
 import { RichText } from '~/components/RichText'
 import Card from '~/lib/card'
 import { Link } from '~/lib/link'
@@ -13,23 +21,33 @@ export default function ActivityDetailPage({
 }: InertiaProps<{
   activity: ActivityDetail
 }>) {
+  let actions: ReactNode
+  let detail: ReactNode
   let title: string
-  let detail = <></>
 
   const { $type } = activity
 
   switch ($type) {
     case 'app.bsky.feed.like':
+      actions = <OpenWith uri={activity.openUri} />
       detail = (
-        <Text>
-          Liked <span className="font-mono text-xs break-all">{activity.subject.uri}</span>
-        </Text>
+        <div className="flex items-center gap-3 rounded-lg border border-dashed border-zinc-300 p-4 text-zinc-500 dark:border-zinc-600 dark:text-zinc-400">
+          <HeartIcon aria-hidden="true" className="size-3.5 shrink-0" />
+          <p className="text-sm">Liked something</p>
+        </div>
       )
       title = 'Like'
       break
     case 'app.bsky.feed.post':
+      actions = <OpenWith uri={activity.openUri} />
       detail = (
         <>
+          {activity.replyUri ? (
+            <div className="flex items-center gap-3 rounded-lg border border-dashed border-zinc-300 p-4 text-sm text-zinc-500 dark:border-zinc-600 dark:text-zinc-400">
+              <ArrowUturnLeftIcon aria-hidden="true" className="size-3.5 shrink-0" />
+              Replying to a post
+            </div>
+          ) : undefined}
           <RichText text={activity.text} />
           {activity.embed ? <Embed embed={activity.embed} /> : undefined}
         </>
@@ -37,17 +55,26 @@ export default function ActivityDetailPage({
       title = 'Post'
       break
     case 'app.bsky.graph.follow':
+      actions = <OpenWith uri={activity.openUri} />
       detail = (
-        <Text>
-          Followed <span className="font-mono text-xs break-all">{activity.subject}</span>
-        </Text>
+        <div className="flex items-center gap-3 rounded-lg border border-dashed border-zinc-300 p-4 text-zinc-500 dark:border-zinc-600 dark:text-zinc-400">
+          <UserPlusIcon aria-hidden="true" className="size-3.5 shrink-0" />
+          <p className="text-sm">Followed something</p>
+        </div>
       )
       title = 'Follow'
       break
     case 'id.sifa.profile.language':
-      title = activity.name
+      detail = (
+        <div className="flex items-center gap-3 rounded-lg border border-dashed border-zinc-300 p-4 text-zinc-500 dark:border-zinc-600 dark:text-zinc-400">
+          <LanguageIcon aria-hidden="true" className="size-3.5 shrink-0" />
+          <p className="text-sm">Added {activity.name}</p>
+        </div>
+      )
+      title = 'Language'
       break
     case 'site.standard.document':
+      actions = <OpenWith uri={activity.openUri} />
       detail = (
         <>
           {activity.description ? (
@@ -69,14 +96,17 @@ export default function ActivityDetailPage({
     <Card className="p-6 sm:p-8">
       <Head title={title} />
 
-      <nav aria-label="Breadcrumb" className="text-sm text-zinc-500 dark:text-zinc-400 mb-8">
-        <Link className="hover:text-zinc-700 dark:hover:text-zinc-300" route="activity.show">
-          <ChevronLeftIcon aria-hidden="true" className="size-4 inline-block" />
-          Your Activity
-        </Link>
-        {' / '}
-        <span aria-current="page">{title}</span>
-      </nav>
+      <div className="mb-8 flex items-start justify-between gap-4">
+        <nav aria-label="Breadcrumb" className="text-sm text-zinc-500 dark:text-zinc-400">
+          <Link className="hover:text-zinc-700 dark:hover:text-zinc-300" route="activity.show">
+            <ChevronLeftIcon aria-hidden="true" className="size-4 inline-block" />
+            Your Activity
+          </Link>
+          {' / '}
+          <span aria-current="page">{title}</span>
+        </nav>
+        {actions}
+      </div>
 
       <div className="mt-6 space-y-3">{detail}</div>
     </Card>

--- a/inertia/utils/apps.ts
+++ b/inertia/utils/apps.ts
@@ -1,0 +1,110 @@
+import { type AtUriParts, type AtUriString, parseAtUriString } from '@atproto/syntax'
+
+type AppResult = [name: string, url: string]
+type AppTransform = (parts: AtUriParts) => string | undefined
+type App = [name: string, transform: AppTransform]
+
+const localStorageKey = 'preferred-apps'
+
+/**
+ * List of supported apps and their URL transformation functions.
+ */
+const apps: ReadonlyArray<App> = [
+  [
+    'Bluesky',
+    (parts) => {
+      const base = `https://bsky.app/profile/${parts.authority}`
+      if (!parts.collection) return base
+      if (parts.collection === 'app.bsky.feed.post' && parts.rkey)
+        return `${base}/post/${parts.rkey}`
+    },
+  ],
+  [
+    'Mu',
+    (parts) => {
+      const base = `https://mu.social/profile/${parts.authority}`
+      if (!parts.collection) return base
+      if (parts.collection === 'app.bsky.feed.post' && parts.rkey)
+        return `${base}/post/${parts.rkey}`
+    },
+  ],
+]
+
+/**
+ * Find apps that can open a given `at://` URI.
+ *
+ * @param atUri
+ *   `at://` URI (example `at://did` or `at://did/collection/rkey`).
+ * @returns
+ *   App names and web URLs.
+ */
+export function find(atUri: AtUriString): Array<AppResult> {
+  const result: Array<AppResult> = []
+  const parsed = parseAtUriString(atUri, { strict: false })
+  if (!parsed.success) return result
+  for (const [name, transform] of apps) {
+    const url = transform(parsed.value)
+    if (url) result.push([name, url])
+  }
+  return result
+}
+
+/**
+ * Read preferred apps.
+ *
+ * @returns
+ *   List of preferred apps.
+ */
+function get(): ReadonlyArray<unknown> {
+  const value = localStorage.getItem(localStorageKey)
+  if (value) {
+    try {
+      const result: unknown = JSON.parse(value)
+      if (Array.isArray(result)) return result
+    } catch {}
+  }
+  return []
+}
+
+/**
+ * Prefer an app.
+ *
+ * Saves a unique list of newest preferred apps,
+ * capped to a reasonable size.
+ *
+ * @param name
+ *   Name of app.
+ * @returns
+ *   Nothing.
+ */
+export function prefer(name: string): undefined {
+  const preferred = [...new Set([name, ...get()])]
+  if (preferred.length > 20) preferred.length = 20
+  localStorage.setItem(localStorageKey, JSON.stringify(preferred))
+}
+
+/**
+ * Sort apps.
+ *
+ * @param list
+ *   List of apps.
+ * @returns
+ *   Sorted apps, preferred apps first then alphabetically.
+ */
+export function sort(list: ReadonlyArray<AppResult>): Array<AppResult> {
+  const preferred = get()
+  const sorted = [...list]
+  sorted.sort(compareApp)
+  return sorted
+
+  function compareApp(left: AppResult, right: AppResult) {
+    // Sort on preferred order first.
+    const leftPosition = preferred.indexOf(left[0])
+    const rightPosition = preferred.indexOf(right[0])
+    if (leftPosition !== -1 && rightPosition !== -1) return leftPosition - rightPosition
+    if (leftPosition !== -1 && rightPosition === -1) return -1
+    if (leftPosition === -1 && rightPosition !== -1) return 1
+    // Sort alphabetically.
+    return left[0].localeCompare(right[0])
+  }
+}


### PR DESCRIPTION
This adds an initial app launching system,
with bluesky and mu,
that can open users (`at://did`) and
bsky posts (`at://did/app.bsky.feed.post/rkey`) for now.

Users can choose which app to use to launch something with. When they choose something, they mark it as preferred.

Closes EUR-131.

Screenshots:

<img width="1648" height="1072" alt="Screenshot 2026-07-14 at 2 12 19 PM" src="https://github.com/user-attachments/assets/bd8adb33-2bab-4497-b135-88cf6415998e" />
<img width="1648" height="1072" alt="Screenshot 2026-07-14 at 2 12 27 PM" src="https://github.com/user-attachments/assets/ae3d6741-24b2-4788-a374-c1eee0981fed" />
