### PR TITLE
Refactor activity feed

### DIFF
--- a/.changeset/tidy-comics-relax.md
+++ b/.changeset/tidy-comics-relax.md
@@ -1,0 +1,5 @@
+---
+'eurosky-portal': patch
+---
+
+Refactor activity feed

--- a/inertia/components/ActivityItem.tsx
+++ b/inertia/components/ActivityItem.tsx
@@ -1,50 +1,64 @@
-import {
-  ChatBubbleLeftIcon,
-  DocumentTextIcon,
-  HeartIcon,
-  LanguageIcon,
-  UserPlusIcon,
-} from '@heroicons/react/24/outline'
+import clsx from 'clsx'
+import { Heart, LucideIcon, MessageSquareText, Newspaper, UserPlus, Languages } from 'lucide-react'
 import type { ActivityRow } from '#services/activity_service'
 import type { SupportedCollection } from '#utils/activity'
+import { ClickableCard } from '~/lib/card'
 import { Link } from '~/lib/link'
 
-type Component = typeof HeartIcon
-
 const icons = {
-  'app.bsky.feed.like': HeartIcon,
-  'app.bsky.feed.post': ChatBubbleLeftIcon,
-  'app.bsky.graph.follow': UserPlusIcon,
-  'id.sifa.profile.language': LanguageIcon,
-  'site.standard.document': DocumentTextIcon,
-} satisfies Record<SupportedCollection, Component>
+  'app.bsky.feed.like': Heart,
+  'app.bsky.feed.post': MessageSquareText,
+  'app.bsky.graph.follow': UserPlus,
+  'id.sifa.profile.language': Languages,
+  'site.standard.document': Newspaper,
+} satisfies Record<SupportedCollection, LucideIcon>
+
+const labels = {
+  'app.bsky.feed.like': 'Like',
+  'app.bsky.feed.post': 'Post',
+  'app.bsky.graph.follow': 'Follow',
+  'id.sifa.profile.language': 'Language',
+  'site.standard.document': 'Article',
+} satisfies Record<SupportedCollection, string>
 
 export function ActivityItem({ activity }: { activity: ActivityRow }) {
   const { collection, createdAt, text, uri } = activity
   const Icon = icons[collection]
+  const label = labels[collection]
   const createdAtDisplay = formatDate(createdAt)
   const rkey = uri.split('/').pop() ?? ''
 
   return (
     <li>
-      <Link
-        className="flex items-center gap-4 px-4 py-4 hover:bg-gray-50 dark:hover:bg-gray-800/50"
+      <ClickableCard
+        as={Link}
+        className="block w-full p-4"
         route="activity.detail"
         routeParams={{ collection, rkey }}
       >
-        <Icon aria-hidden="true" className="h-5 w-5 shrink-0 text-gray-400 dark:text-gray-500" />
-        <span className="flex-1 min-w-0 truncate text-sm text-gray-900 dark:text-white">
-          {text}
-        </span>
-        <span className="shrink-0 whitespace-nowrap break-all text-xs text-gray-600 dark:text-gray-400 font-mono">
-          {collection}
-        </span>
-        {createdAtDisplay && (
-          <span className="shrink-0 whitespace-nowrap break-all text-sm text-gray-600 dark:text-gray-400">
-            {createdAtDisplay}
+        <div className="flex items-center gap-2">
+          <span className="inline-flex items-center gap-1.5 rounded-md border border-zinc-300 px-2 py-1 text-sm font-medium dark:border-zinc-600">
+            <Icon aria-hidden="true" className="h-4 w-4" />
+            {label}
           </span>
+          {createdAtDisplay ? (
+            <>
+              <span className="text-sm">Created on {createdAtDisplay}</span>
+            </>
+          ) : undefined}
+        </div>
+        {text && (
+          <p
+            className={clsx('mt-2', {
+              'font-bold': collection === 'site.standard.document',
+              'text-sm': collection !== 'site.standard.document',
+              'text-xl': collection === 'site.standard.document',
+            })}
+          >
+            {text}
+          </p>
         )}
-      </Link>
+      </ClickableCard>
     </li>
   )
 }

--- a/inertia/components/ActivityList.tsx
+++ b/inertia/components/ActivityList.tsx
@@ -3,7 +3,7 @@ import { ActivityItem } from '~/components/ActivityItem'
 
 export function ActivityList({ activities }: { activities: Array<ActivityRow> }) {
   return (
-    <ul className="divide-y divide-gray-100 dark:divide-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
+    <ul className="flex flex-col gap-3">
       {activities.map((activity) => (
         <ActivityItem activity={activity} key={activity.uri} />
       ))}

--- a/inertia/pages/activity/show.tsx
+++ b/inertia/pages/activity/show.tsx
@@ -1,9 +1,12 @@
 import { useEffect } from 'react'
 import { router } from '@inertiajs/react'
+import { TriangleAlert } from 'lucide-react'
 import type { GetRecordsResult } from '#services/activity_service'
 import { urlFor } from '~/client'
 import { ActivityList } from '~/components/ActivityList'
 import { Button } from '~/lib/button'
+import Card from '~/lib/card'
+import { Text } from '~/lib/text'
 import type { InertiaProps } from '~/types'
 
 const pageSize = 20
@@ -25,6 +28,28 @@ export default function Activity(result: InertiaProps<GetRecordsResult>) {
             : `Showing ${result.activities.length} of ${result.total} ${result.total === 1 ? 'activity' : 'activities'}.`}
         </p>
       </div>
+
+      <Card className="p-4 bg-amber-50! dark:bg-amber-400/10! flex flex-row gap-3">
+        <TriangleAlert className="mt-1 h-5 w-5 shrink-0 text-amber-400" />
+        <div>
+          <Text className="font-semibold text-amber-800! dark:text-amber-200!">
+            Under construction
+          </Text>
+          <Text className="text-amber-700! dark:text-amber-200/80!">
+            Your activity feed is currently in development. Some of your activity may be missing. We
+            will add more activity soon.
+          </Text>
+          <Text className="text-amber-700! dark:text-amber-200/80!">
+            <a
+              className="font-semibold underline hover:text-amber-900 dark:hover:text-amber-100"
+              // TODO: use a real link when Sherif makes it!
+              href="#"
+            >
+              Give feedback
+            </a>
+          </Text>
+        </div>
+      </Card>
 
       {result.state === 'syncing' ? null : result.activities.length === 0 ? (
         <p className="text-gray-500 dark:text-gray-400">No records found.</p>

--- a/inertia/pages/activity/show.tsx
+++ b/inertia/pages/activity/show.tsx
@@ -9,6 +9,8 @@ import Card from '~/lib/card'
 import { Text } from '~/lib/text'
 import type { InertiaProps } from '~/types'
 
+const feedbackUrl = 'https://userinput.app/#/s/did:plc:ooensn4mr5mhznzypvxelfa3/3mr5gmbhteg2p';
+
 const pageSize = 20
 
 export default function Activity(result: InertiaProps<GetRecordsResult>) {
@@ -42,8 +44,7 @@ export default function Activity(result: InertiaProps<GetRecordsResult>) {
           <Text className="text-amber-700! dark:text-amber-200/80!">
             <a
               className="font-semibold underline hover:text-amber-900 dark:hover:text-amber-100"
-              // TODO: use a real link when Sherif makes it!
-              href="#"
+              href={feedbackUrl}
             >
               Give feedback
             </a>

--- a/inertia/pages/activity/show.tsx
+++ b/inertia/pages/activity/show.tsx
@@ -9,7 +9,7 @@ import Card from '~/lib/card'
 import { Text } from '~/lib/text'
 import type { InertiaProps } from '~/types'
 
-const feedbackUrl = 'https://userinput.app/#/s/did:plc:ooensn4mr5mhznzypvxelfa3/3mr5gmbhteg2p';
+const feedbackUrl = 'https://userinput.app/#/s/did:plc:ooensn4mr5mhznzypvxelfa3/3mr5gmbhteg2p'
 
 const pageSize = 20
 

--- a/inertia/pages/activity/show.tsx
+++ b/inertia/pages/activity/show.tsx
@@ -32,7 +32,7 @@ export default function Activity(result: InertiaProps<GetRecordsResult>) {
       </div>
 
       <Card className="p-4 bg-amber-50! dark:bg-amber-400/10! flex flex-row gap-3">
-        <TriangleAlert className="mt-1 h-5 w-5 shrink-0 text-amber-400" />
+        <TriangleAlert aria-hidden="true" className="mt-1 h-5 w-5 shrink-0 text-amber-400" />
         <div>
           <Text className="font-semibold text-amber-800! dark:text-amber-200!">
             Under construction

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "clsx": "^2.1.1",
     "edge-markdown": "^1.10.1",
     "edge.js": "^6.5.0",
+    "lucide-react": "^1.24.0",
     "luxon": "^3.7.2",
     "micromark": "^4.0.2",
     "motion": "^12.38.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       edge.js:
         specifier: ^6.5.0
         version: 6.5.0
+      lucide-react:
+        specifier: ^1.24.0
+        version: 1.24.0(react@19.2.5)
       luxon:
         specifier: ^3.7.2
         version: 3.7.2
@@ -4402,6 +4405,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@1.24.0:
+    resolution: {integrity: sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   luxon@3.7.2:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
@@ -10430,6 +10438,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@1.24.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   luxon@3.7.2: {}
 


### PR DESCRIPTION
Important: @bravestarfish needs to provide a url for `inertia/pages/activity/show.tsx`.

* add “in development” block above activity feed
* use cards for activity feed instead of table/rows
* change to use lucide icons

Some design improvements coordinated with @renderghost.

Closes EUR-195