### PR TITLE
Fix to use `history` for backlinks

### DIFF
--- a/.changeset/breezy-meals-burn.md
+++ b/.changeset/breezy-meals-burn.md
@@ -1,0 +1,5 @@
+---
+'eurosky-portal': patch
+---
+
+Fix to use `history` for backlinks

--- a/inertia/lib/link.tsx
+++ b/inertia/lib/link.tsx
@@ -10,6 +10,27 @@ import * as Headless from '@headlessui/react'
 import { Link as InertiaLink, type LinkProps } from '@adonisjs/inertia/react'
 import React, { forwardRef } from 'react'
 
+/**
+ * `Link` that uses `history.back()` when possible, meaning scroll position and
+ * pagination are restored, and falls back to a normal link otherwise.
+ */
+export const BackLink = forwardRef(function BackLink(
+  props: LinkProps,
+  ref: React.ForwardedRef<HTMLAnchorElement>
+) {
+  return (
+    <Link
+      {...props}
+      onClick={(event) => {
+        if (window.history.length <= 1) return
+        event.preventDefault()
+        window.history.back()
+      }}
+      ref={ref}
+    />
+  )
+})
+
 export const Link = forwardRef(function Link(
   props: LinkProps,
   ref: React.ForwardedRef<HTMLAnchorElement>

--- a/inertia/pages/activity/detail.tsx
+++ b/inertia/pages/activity/detail.tsx
@@ -12,7 +12,7 @@ import { Embed } from '~/components/Embed'
 import { OpenWith } from '~/components/OpenWith'
 import { RichText } from '~/components/RichText'
 import Card from '~/lib/card'
-import { Link } from '~/lib/link'
+import { BackLink } from '~/lib/link'
 import { Text } from '~/lib/text'
 import type { InertiaProps } from '~/types'
 
@@ -98,10 +98,10 @@ export default function ActivityDetailPage({
 
       <div className="mb-8 flex items-start justify-between gap-4">
         <nav aria-label="Breadcrumb" className="text-sm text-zinc-500 dark:text-zinc-400">
-          <Link className="hover:text-zinc-700 dark:hover:text-zinc-300" route="activity.show">
+          <BackLink className="hover:text-zinc-700 dark:hover:text-zinc-300" route="activity.show">
             <ChevronLeftIcon aria-hidden="true" className="size-4 inline-block" />
             Your Activity
-          </Link>
+          </BackLink>
           {' / '}
           <span aria-current="page">{title}</span>
         </nav>

--- a/inertia/pages/apps/detail.tsx
+++ b/inertia/pages/apps/detail.tsx
@@ -9,7 +9,7 @@ import { Avatar } from '~/lib/avatar'
 import { Badge } from '~/lib/badge'
 import Card from '~/lib/card'
 import { Heading } from '~/lib/heading'
-import { Link } from '~/lib/link'
+import { BackLink } from '~/lib/link'
 import { Text } from '~/lib/text'
 import { InertiaProps } from '~/types'
 
@@ -44,10 +44,10 @@ export default function AppDetailPage({ app }: InertiaProps<{ app: Data.App }>) 
       <Head title={name} />
 
       <nav aria-label="Breadcrumb" className="text-sm text-zinc-500 dark:text-zinc-400 mb-8">
-        <Link className="hover:text-zinc-700 dark:hover:text-zinc-300" route="discover.apps">
+        <BackLink className="hover:text-zinc-700 dark:hover:text-zinc-300" route="discover.apps">
           <ChevronLeftIcon aria-hidden="true" className="size-4 inline-block" />
           Applications
-        </Link>
+        </BackLink>
         {' / '}
         <span aria-current="page">{name}</span>
       </nav>


### PR DESCRIPTION
This PR adds backlinks to detail pages which actually navigate back. That means a) pagination remains, b) scrolling remains, c) things are fast because it’s in the cache already.