### PR TITLE
Add user info to follow activity detail page

### DIFF
--- a/.changeset/every-dodos-push.md
+++ b/.changeset/every-dodos-push.md
@@ -1,0 +1,5 @@
+---
+'eurosky-portal': patch
+---
+
+Add user info to follow activity detail page

--- a/app/controllers/activity_controller.ts
+++ b/app/controllers/activity_controller.ts
@@ -1,9 +1,12 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import activityService from '#services/activity_service'
+import { type BskyAppProfile, BskyAppService } from '#services/bsky_app_service'
 import ActivityTransformer from '#transformers/activity_transformer'
 import { activityDetailValidator, activityQueryValidator } from '#validators/activity'
 
 export default class ActivityController {
+  #bskyApp = new BskyAppService()
+
   async show({ auth, inertia, request }: HttpContext) {
     const { did } = await auth.getUserOrFail()
     const { limit, snapshot } = await request.validateUsing(activityQueryValidator)
@@ -34,6 +37,13 @@ export default class ActivityController {
     if (!record) return response.notFound()
     const { pds, uri, value } = record
     const activity = new ActivityTransformer(value, { did, pds, uri }).toObject()
-    return inertia.render('activity/detail', { activity })
+    let profile: BskyAppProfile | undefined
+
+    // Fetch who was followed on detail pages.
+    if (activity.$type === 'app.bsky.graph.follow') {
+      profile = await this.#bskyApp.getProfile(activity.subject)
+    }
+
+    return inertia.render('activity/detail', { activity, profile })
   }
 }

--- a/app/services/bsky_app_service.ts
+++ b/app/services/bsky_app_service.ts
@@ -1,0 +1,54 @@
+import logger from '@adonisjs/core/services/logger'
+import cache from '@adonisjs/cache/services/main'
+import type { l } from '@atproto/lex'
+import { xrpcSafe } from '@atproto/lex'
+import { Monocle } from '@monocle.sh/adonisjs-agent'
+import * as lexicon from '#lexicons'
+
+export type BskyAppProfile = Pick<
+  lexicon.app.bsky.actor.defs.ProfileViewDetailed,
+  'avatar' | 'displayName' | 'handle'
+>
+
+/**
+ * Read public and unauthenticated data from the public Bluesky API.
+ */
+export class BskyAppService {
+  private baseUrl = 'https://public.api.bsky.app'
+
+  /**
+   * Get a profile (`app.bsky.actor.getProfile`) with cache.
+   *
+   * @param did
+   *   DID.
+   * @returns
+   *   Profile.
+   */
+  async getProfile(did: l.DidString) {
+    return cache.getOrSet({
+      factory: (ctx) => this.#getProfile(did).then((r) => r ?? ctx.skip()),
+      grace: '10m',
+      key: `bsky-app-profile:${did}`,
+      ttl: '10m',
+    })
+  }
+
+  async #getProfile(did: l.DidString): Promise<BskyAppProfile | undefined> {
+    const result = await xrpcSafe(this.baseUrl, lexicon.app.bsky.actor.getProfile.main, {
+      params: { actor: did },
+      signal: AbortSignal.timeout(1000),
+    })
+
+    if (!result.success) {
+      logger.error(result, 'Invalid response from Bluesky App')
+      Monocle.captureException(result, {
+        extra: { did },
+        tags: { component: 'bsky_app_service' },
+      })
+      return
+    }
+
+    const { avatar, displayName, handle } = result.body
+    return { avatar, displayName, handle }
+  }
+}

--- a/app/transformers/activity_transformer.ts
+++ b/app/transformers/activity_transformer.ts
@@ -73,8 +73,9 @@ class AppBskyFeedPost extends BaseTransformer<lexicon.app.bsky.feed.post.Main> {
 
 class AppBskyGraphFollow extends BaseTransformer<lexicon.app.bsky.graph.follow.Main> {
   toObject() {
-    const openUri: AtUriString = `at://${this.resource.subject}`
-    return { ...this.pick(this.resource, ['$type']), openUri }
+    const { subject } = this.resource
+    const openUri: AtUriString = `at://${subject}`
+    return { ...this.pick(this.resource, ['$type']), openUri, subject }
   }
 }
 

--- a/inertia/pages/activity/detail.tsx
+++ b/inertia/pages/activity/detail.tsx
@@ -3,14 +3,15 @@ import {
   ChevronLeftIcon,
   HeartIcon,
   LanguageIcon,
-  UserPlusIcon,
 } from '@heroicons/react/20/solid'
 import { Head } from '@inertiajs/react'
 import type { ReactNode } from 'react'
+import type { BskyAppProfile } from '#services/bsky_app_service'
 import type { ActivityDetail } from '#transformers/activity_transformer'
 import { Embed } from '~/components/Embed'
 import { OpenWith } from '~/components/OpenWith'
 import { RichText } from '~/components/RichText'
+import { Avatar } from '~/lib/avatar'
 import Card from '~/lib/card'
 import { Link } from '~/lib/link'
 import { Text } from '~/lib/text'
@@ -18,8 +19,10 @@ import type { InertiaProps } from '~/types'
 
 export default function ActivityDetailPage({
   activity,
+  profile,
 }: InertiaProps<{
   activity: ActivityDetail
+  profile?: BskyAppProfile | undefined
 }>) {
   let actions: ReactNode
   let detail: ReactNode
@@ -54,16 +57,24 @@ export default function ActivityDetailPage({
       )
       title = 'Post'
       break
-    case 'app.bsky.graph.follow':
+    case 'app.bsky.graph.follow': {
+      const name = profile
+        ? profile.displayName || (profile.handle ? '@' + profile.handle : undefined)
+        : undefined
       actions = <OpenWith uri={activity.openUri} />
       detail = (
-        <div className="flex items-center gap-3 rounded-lg border border-dashed border-zinc-300 p-4 text-zinc-500 dark:border-zinc-600 dark:text-zinc-400">
-          <UserPlusIcon aria-hidden="true" className="size-3.5 shrink-0" />
-          <p className="text-sm">Followed something</p>
+        <div className="flex items-center gap-3">
+          {profile ? (
+            <Avatar className="size-10 shrink-0 bg-amber-100 text-amber-700" src={profile.avatar} />
+          ) : undefined}
+          <p className="text-sm text-zinc-900 dark:text-white">
+            You followed <span className={name ? 'font-bold' : undefined}>{name || 'someone'}</span>
+          </p>
         </div>
       )
       title = 'Follow'
       break
+    }
     case 'id.sifa.profile.language':
       detail = (
         <div className="flex items-center gap-3 rounded-lg border border-dashed border-zinc-300 p-4 text-zinc-500 dark:border-zinc-600 dark:text-zinc-400">


### PR DESCRIPTION
This adds some info to the detail page of `app.bsky.graph.follow` activities.
Just the display name or handle, and avatar.
Like the inverse of when someone follows you on bsky.

Screenshots:

<img width="686" height="482" alt="Screenshot 2026-07-20 at 3 38 16 PM" src="https://github.com/user-attachments/assets/5f655de4-a0fa-4d1f-a131-574875e788c4" />
