### PR TITLE
Fix to limit default cache memory

### DIFF
--- a/.changeset/bumpy-words-laugh.md
+++ b/.changeset/bumpy-words-laugh.md
@@ -1,0 +1,5 @@
+---
+'eurosky-portal': patch
+---
+
+Fix to limit default cache memory

--- a/config/cache.ts
+++ b/config/cache.ts
@@ -7,7 +7,7 @@ const cacheConfig = defineConfig({
     memoryOnly: store().useL1Layer(drivers.memory({ maxSize: '400mb' })),
 
     default: store()
-      .useL1Layer(drivers.memory())
+      .useL1Layer(drivers.memory({ maxSize: '400mb' }))
       .useL2Layer(
         drivers.database({
           connectionName: 'sqlite',


### PR DESCRIPTION
The `memoryOnly` a couple lines higher already had this. Now also for the `default`.