### PR TITLE
Fix to remove unneeded `prune` call

### DIFF
--- a/.changeset/hungry-ants-crash.md
+++ b/.changeset/hungry-ants-crash.md
@@ -1,0 +1,5 @@
+---
+'eurosky-portal': patch
+---
+
+Fix to remove unneeded `prune` call

--- a/app/services/activity_service.ts
+++ b/app/services/activity_service.ts
@@ -127,6 +127,7 @@ export class ActivityService {
   async backfillCollection(did: DidString, collection: SupportedCollection): Promise<undefined> {
     const { client } = await this.#clientFor(did)
     await this.#syncCollection(client, did, collection, DateTime.now())
+    await this.prune(did)
   }
 
   /**
@@ -408,7 +409,6 @@ export class ActivityService {
 
       if (update.length > 0) await ActivityRecord.updateOrCreateMany('uri', update)
       if (remove.length > 0) await ActivityRecord.query().whereIn('uri', remove).delete()
-      await this.prune(did)
 
       cursor = result.body.cursor
     } while (cursor)


### PR DESCRIPTION
This prune call happens per page; but it also happens right after the whole `#sync`. That’s enough