### PR TITLE
fix: use correct health check endpoint in compose

### DIFF
--- a/service/compose.yml
+++ b/service/compose.yml
@@ -29,7 +29,7 @@ services:
     network_mode: host
     healthcheck:
       # prettier-ignore
-      test: ['CMD-SHELL',"curl -s --noproxy localhost localhost:4075/health | grep -q 'OK' || exit 1"]
+      test: ['CMD-SHELL',"curl -s --noproxy localhost localhost:4075/_health | grep -qi 'OK' || exit 1"]
     labels:
       - 'com.centurylinklabs.watchtower.enable=true'
 


### PR DESCRIPTION
`/health` was 404ing and marking the service as unhealthy because the endpoint
was mispelled (it is `/_health`) and the response body was `ok` and not `OK`
(mind the capitalization).

The PR fixes the path and adds a `-i` for case-unsensitive grepping.
