### PR TITLE
Fix resync collection on active users

### DIFF
--- a/.changeset/legal-states-press.md
+++ b/.changeset/legal-states-press.md
@@ -1,0 +1,5 @@
+---
+'eurosky-portal': patch
+---
+
+Fix resync collection on active users

--- a/commands/portal_resync_collection.ts
+++ b/commands/portal_resync_collection.ts
@@ -47,6 +47,7 @@ export default class PortalResyncCollection extends BaseCommand {
     while (more) {
       const result = await Account.query()
         .where('lastActiveAt', '>=', toSqlDateTime(dormancyCutoff()))
+        .whereNotNull('lastActivitySyncAt')
         .orderBy('did')
         .paginate(page + 1, 50)
 


### PR DESCRIPTION
The command should only do work for users that used the activity feed, not all active users.