### PR TITLE
Fix order of pagination

### DIFF
--- a/.changeset/fancy-rockets-dance.md
+++ b/.changeset/fancy-rockets-dance.md
@@ -1,0 +1,5 @@
+---
+'eurosky-portal': patch
+---
+
+Fix order of pagination

--- a/app/services/activity_service.ts
+++ b/app/services/activity_service.ts
@@ -423,7 +423,6 @@ export class ActivityService {
           cursor,
           limit: 100,
           repo: did,
-          reverse: true,
           signal: AbortSignal.timeout(10_000),
         })
       )


### PR DESCRIPTION
This is what caused posts / likes not to show for accounts with many of them.
I thought it was the other way around (with a small throwaway account). Now verified with a full account that things are ordered the other way around, newest-first, by default.