### PR TITLE
Fix big warning on deactivated repos

### DIFF
--- a/.adonisjs/server/events.ts
+++ b/.adonisjs/server/events.ts
@@ -6,10 +6,10 @@
 import ActivityBackfillCompleted from '#events/activity_backfill_completed'
 import ActivityBackfillStarted from '#events/activity_backfill_started'
 import ActivityFeedViewed from '#events/activity_feed_viewed'
-import PageViewed from '#events/page_viewed'
-import AuthFlowStarted from '#events/auth_flow_started'
 import AuthFlowCompleted from '#events/auth_flow_completed'
+import AuthFlowStarted from '#events/auth_flow_started'
 import AuthLoggedOut from '#events/auth_logged_out'
+import PageViewed from '#events/page_viewed'
 import TermsAccepted from '#events/terms_accepted'
 import WelcomeDismissed from '#events/welcome_dismissed'
 
@@ -17,10 +17,10 @@ export const events = {
   ActivityBackfillCompleted: ActivityBackfillCompleted,
   ActivityBackfillStarted: ActivityBackfillStarted,
   ActivityFeedViewed: ActivityFeedViewed,
-  PageViewed: PageViewed,
-  AuthFlowStarted: AuthFlowStarted,
   AuthFlowCompleted: AuthFlowCompleted,
+  AuthFlowStarted: AuthFlowStarted,
   AuthLoggedOut: AuthLoggedOut,
+  PageViewed: PageViewed,
   TermsAccepted: TermsAccepted,
   WelcomeDismissed: WelcomeDismissed,
 }

--- a/.adonisjs/server/listeners.ts
+++ b/.adonisjs/server/listeners.ts
@@ -7,10 +7,10 @@ export const listeners = {
   TrackActivityBackfillCompleted: () => import('#listeners/track_activity_backfill_completed'),
   TrackActivityBackfillStarted: () => import('#listeners/track_activity_backfill_started'),
   TrackActivityFeedViewed: () => import('#listeners/track_activity_feed_viewed'),
-  TrackPageViewed: () => import('#listeners/track_page_viewed'),
-  TrackAuthFlowStarted: () => import('#listeners/track_auth_flow_started'),
   TrackAuthFlowCompleted: () => import('#listeners/track_auth_flow_completed'),
+  TrackAuthFlowStarted: () => import('#listeners/track_auth_flow_started'),
   TrackAuthLoggedOut: () => import('#listeners/track_auth_logged_out'),
+  TrackPageViewed: () => import('#listeners/track_page_viewed'),
   TrackTermsAccepted: () => import('#listeners/track_terms_accepted'),
   TrackWelcomeDismissed: () => import('#listeners/track_welcome_dismissed'),
 }

--- a/.changeset/yummy-trees-ask.md
+++ b/.changeset/yummy-trees-ask.md
@@ -1,0 +1,5 @@
+---
+'eurosky-portal': patch
+---
+
+Fix big warning on deactived repos

--- a/.changeset/yummy-trees-ask.md
+++ b/.changeset/yummy-trees-ask.md
@@ -2,4 +2,4 @@
 'eurosky-portal': patch
 ---
 
-Fix big warning on deactived repos
+Fix big warning on deactivated repos

--- a/app/services/activity_service.ts
+++ b/app/services/activity_service.ts
@@ -164,7 +164,7 @@ export class ActivityService {
   async backfill(did: DidString): Promise<undefined> {
     const { client } = await this.#clientFor(did)
 
-    let describeResponse
+    let describeResponse: XrpcResponse<typeof lexicon.com.atproto.repo.describeRepo.main>
     try {
       describeResponse = await withRateLimitRetry(() =>
         client.xrpc(lexicon.com.atproto.repo.describeRepo.main, {
@@ -172,7 +172,7 @@ export class ActivityService {
           signal: AbortSignal.timeout(5000),
         })
       )
-    } catch (err) {
+    } catch (err: unknown) {
       // Nothing to try right now. But also not permanent.
       if (
         err instanceof XrpcResponseError &&

--- a/app/services/activity_service.ts
+++ b/app/services/activity_service.ts
@@ -163,12 +163,29 @@ export class ActivityService {
    */
   async backfill(did: DidString): Promise<undefined> {
     const { client } = await this.#clientFor(did)
-    const describeResponse = await withRateLimitRetry(() =>
-      client.xrpc(lexicon.com.atproto.repo.describeRepo.main, {
-        params: { repo: did },
-        signal: AbortSignal.timeout(5000),
-      })
-    )
+
+    let describeResponse
+    try {
+      describeResponse = await withRateLimitRetry(() =>
+        client.xrpc(lexicon.com.atproto.repo.describeRepo.main, {
+          params: { repo: did },
+          signal: AbortSignal.timeout(5000),
+        })
+      )
+    } catch (err) {
+      // Nothing to try right now. But also not permanent.
+      if (
+        err instanceof XrpcResponseError &&
+        (err.error === 'RepoDeactivated' ||
+          err.error === 'RepoNotFound' ||
+          err.error === 'RepoTakendown')
+      ) {
+        logger.info({ did, err }, 'activity: repo unavailable, skipping backfill')
+        return
+      }
+
+      throw err
+    }
 
     const collections = describeResponse.body.collections.filter(isSupportedCollection)
     const indexedAt = DateTime.now()


### PR DESCRIPTION
Saw this big warning in the logs; user in question reactivated soon after. So, no need to be loud about this problem.

Also includes a tiny adonisjs change that its live server generates, which should’ve been in another PR.