### PR TITLE
Add plugin for portal branding

### DIFF
--- a/adonisrc.ts
+++ b/adonisrc.ts
@@ -63,6 +63,7 @@ export default defineConfig({
     () => import('@adonisjs/inertia/inertia_provider'),
     () => import('@adonisjs/auth/auth_provider'),
     () => import('#providers/api_provider'),
+    () => import('#providers/plugin_registry_provider'),
     () => import('#providers/jetstream_provider'),
     () => import('#providers/queue_worker_provider'),
     () => import('@thisismissem/adonisjs-atproto-oauth/provider'),

--- a/app/controllers/oauth_controller.ts
+++ b/app/controllers/oauth_controller.ts
@@ -1,4 +1,5 @@
 import type { HttpContext } from '@adonisjs/core/http'
+import app from '@adonisjs/core/services/app'
 import { Monocle } from '@monocle.sh/adonisjs-agent'
 import { OAuthCallbackError, OAuthResolverError } from '@atproto/oauth-client-node'
 import { isUriString, asAtIdentifierString, type AtIdentifierString } from '@atproto/lex'
@@ -10,6 +11,7 @@ import AuthFlowStarted from '#events/auth_flow_started'
 import AuthLoggedOut from '#events/auth_logged_out'
 import activityService from '#services/activity_service'
 import jetstreamService from '#services/jetstream_service'
+import PluginRegistry from '#services/plugin_registry'
 import { SlingshotService } from '#services/slingshot_service'
 import { loginRequestValidator, signupRequestValidator } from '#validators/oauth'
 import { createFieldError } from '#utils/errors'
@@ -59,6 +61,8 @@ export default class OAuthController {
   }
 
   async login({ request, inertia, oauth, session, logger }: HttpContext) {
+    const pluginRegistry = await app.container.make(PluginRegistry)
+    const { name: brandName } = pluginRegistry.brand
     const data = await request.validateUsing(loginRequestValidator, {
       meta: {
         handleDomain,
@@ -66,7 +70,7 @@ export default class OAuthController {
       messagesProvider: {
         getMessage(defaultMessage, rule, field) {
           if (rule === 'at-handle' || rule === 'at-handle-username') {
-            return `Please enter a valid Atmosphere account, e.g., username${handleDomain ?? '.bsky.social'}`
+            return `Please enter a valid Atmosphere account, e.g., ${handleDomain ? `username${handleDomain}` : 'username.example.com'}`
           }
 
           return defaultMessage.replace(/\{\{\s*field\s*\}\}/, field.getFieldPath())
@@ -94,7 +98,7 @@ export default class OAuthController {
         throw createFieldError(
           'input',
           input,
-          'Currently the Eurosky portal is only available for Eurosky accounts.'
+          `Currently the ${brandName} portal is only available for ${brandName} accounts.`
         )
       }
 
@@ -124,7 +128,7 @@ export default class OAuthController {
           throw createFieldError(
             'input',
             input,
-            'Currently the Eurosky portal is only available for Eurosky accounts.'
+            `Currently the ${brandName} portal is only available for ${brandName} accounts.`
           )
         }
       }
@@ -183,7 +187,7 @@ export default class OAuthController {
     //
     // const registrationSupported = await oauth.canRegister(oauthServerUrl)
     // if (!registrationSupported) {
-    // // Handle registration not supported, this should never be the case for Eurosky:
+    // // Handle registration not supported, this should never be the case for the configured portal:
     //   return response.abort('Registration not supported')
     // }
 

--- a/app/middleware/inertia_middleware.ts
+++ b/app/middleware/inertia_middleware.ts
@@ -8,6 +8,9 @@ import BaseInertiaMiddleware from '@adonisjs/inertia/inertia_middleware'
 import Account from '#models/account'
 import PluginRegistry from '#services/plugin_registry'
 import AccountTransformer from '#transformers/account_transformer'
+import { getHandleDomain } from '#utils/oauth'
+
+const handleDomain = getHandleDomain()
 
 export default class InertiaMiddleware extends BaseInertiaMiddleware {
   async share(ctx: HttpContext) {
@@ -60,6 +63,7 @@ export default class InertiaMiddleware extends BaseInertiaMiddleware {
         error: error,
       }),
       brand: ctx.inertia.always({ ...pluginRegistry.brand }),
+      handleDomain: ctx.inertia.always(handleDomain),
       isAuthenticated: !!auth?.user,
       authorizationServer: ctx.inertia.always(auth?.user?.authorizationServer),
       user: ctx.inertia.always(

--- a/app/middleware/inertia_middleware.ts
+++ b/app/middleware/inertia_middleware.ts
@@ -2,9 +2,11 @@ import '@inertiajs/core'
 import type { InferSharedProps } from '@adonisjs/inertia/types'
 import type { HttpContext } from '@adonisjs/core/http'
 import type { NextFn } from '@adonisjs/core/types/http'
+import app from '@adonisjs/core/services/app'
 import { Monocle } from '@monocle.sh/adonisjs-agent'
 import BaseInertiaMiddleware from '@adonisjs/inertia/inertia_middleware'
 import Account from '#models/account'
+import PluginRegistry from '#services/plugin_registry'
 import AccountTransformer from '#transformers/account_transformer'
 
 export default class InertiaMiddleware extends BaseInertiaMiddleware {
@@ -18,6 +20,7 @@ export default class InertiaMiddleware extends BaseInertiaMiddleware {
      * with all the properties
      */
     const { auth, session, oauth } = ctx as Partial<HttpContext>
+    const pluginRegistry = await app.container.make(PluginRegistry)
 
     let account: Account | undefined
     if (auth?.user?.did) {
@@ -56,6 +59,7 @@ export default class InertiaMiddleware extends BaseInertiaMiddleware {
       flash: ctx.inertia.always({
         error: error,
       }),
+      brand: ctx.inertia.always({ ...pluginRegistry.brand }),
       isAuthenticated: !!auth?.user,
       authorizationServer: ctx.inertia.always(auth?.user?.authorizationServer),
       user: ctx.inertia.always(

--- a/app/services/atstore_service.ts
+++ b/app/services/atstore_service.ts
@@ -79,7 +79,7 @@ const localAppSchema = vine.object({
   'madeInEurope': vine.boolean().optional(),
 
   /**
-   * Custom category: apps recommended by eurosky.
+   * Custom category: apps recommended by the portal.
    */
   'recommended': vine.boolean().optional(),
 })

--- a/app/services/plugin_registry.ts
+++ b/app/services/plugin_registry.ts
@@ -1,11 +1,11 @@
 export interface BrandIdentity {
   name: string
   nameShort: string
-  tagline: string
+  taglineLead: string
   helpUrl: string
   contactUrl: string
   feedbackUrl?: string
-  ecosystemName?: string
+  homeDescriptor?: string
 }
 
 export interface PluginDefinition {
@@ -16,11 +16,11 @@ export interface PluginDefinition {
 export const defaultBrand: BrandIdentity = {
   name: 'Eurosky',
   nameShort: 'Eurosky',
-  tagline: 'Your Portal to the Atmosphere',
+  taglineLead: 'Your Portal to',
   helpUrl: 'https://eurosky.tech/help/',
   contactUrl: 'https://eurosky.tech/contact/',
   feedbackUrl: 'https://userinput.app/#/s/did:plc:ooensn4mr5mhznzypvxelfa3/3mr5gmbhteg2p',
-  ecosystemName: 'the Atmosphere',
+  homeDescriptor: 'European',
 }
 
 export default class PluginRegistry {

--- a/app/services/plugin_registry.ts
+++ b/app/services/plugin_registry.ts
@@ -1,0 +1,42 @@
+export interface BrandIdentity {
+  name: string
+  nameShort: string
+  tagline: string
+  helpUrl: string
+  contactUrl: string
+  feedbackUrl?: string
+  ecosystemName?: string
+}
+
+export interface PluginDefinition {
+  id: string
+  brand?: Partial<BrandIdentity>
+}
+
+export const defaultBrand: BrandIdentity = {
+  name: 'Eurosky',
+  nameShort: 'Eurosky',
+  tagline: 'Your Portal to the Atmosphere',
+  helpUrl: 'https://eurosky.tech/help/',
+  contactUrl: 'https://eurosky.tech/contact/',
+  feedbackUrl: 'https://userinput.app/#/s/did:plc:ooensn4mr5mhznzypvxelfa3/3mr5gmbhteg2p',
+  ecosystemName: 'the Atmosphere',
+}
+
+export default class PluginRegistry {
+  #plugins: PluginDefinition[] = []
+
+  register(plugin: PluginDefinition): void {
+    this.#plugins.push(plugin)
+  }
+
+  get plugins(): ReadonlyArray<PluginDefinition> {
+    return [...this.#plugins]
+  }
+
+  get brand(): BrandIdentity {
+    return this.#plugins.reduce<BrandIdentity>((brand, plugin) => ({ ...brand, ...plugin.brand }), {
+      ...defaultBrand,
+    })
+  }
+}

--- a/app/validators/oauth.ts
+++ b/app/validators/oauth.ts
@@ -7,9 +7,9 @@ export const loginRequestValidator = vine.create({
   input: vine.unionOfTypes([
     vine.atproto.did(),
     vine.atproto.service(),
-    // We allow login with username, @username, @username.eurosky.social, username@eurosky.social or
-    // @username@eurosky.social. These aren't standard handle formats, but what
-    // we've seen entered during user testing.
+    // We allow login with username, @username, username@domain or
+    // @username@domain. These aren't standard handle formats, but what we've
+    // seen entered during user testing.
     vine.atproto.handle().parse((value) => {
       if (typeof value === 'string') {
         let newValue = value
@@ -29,7 +29,7 @@ export const loginRequestValidator = vine.create({
         }
 
         // Remove @ signs separating username from handle domain component:
-        // e.g., username@eurosky.social, but only if it's the handle domain
+        // e.g., username@configured-domain, but only if it's the handle domain
         // so username@gmail.com won't be converted to username.gmail.com
         if (handleDomain && newValue.includes('@') && newValue.endsWith(handleDomain)) {
           newValue = newValue.replace('@', '.')

--- a/config/atproto_oauth.ts
+++ b/config/atproto_oauth.ts
@@ -4,13 +4,14 @@ import {
   lucidStateStore,
 } from '@thisismissem/adonisjs-atproto-oauth'
 import env from '#start/env'
+import { defaultBrand } from '#services/plugin_registry'
 
 export default defineConfig({
   publicUrl: env.get('APP_URL'),
   metadata: {
     // If ATPROTO_OAUTH_CLIENT_ID is set, the client metadata will be fetched from that URL:
     client_id: env.get('ATPROTO_OAUTH_CLIENT_ID'),
-    client_name: 'Eurosky Portal',
+    client_name: `${defaultBrand.name} Portal`,
     client_uri: new URL('/', env.get('APP_URL')).toString(),
     // See: https://atproto.com/guides/scopes
     scope: [

--- a/config/session.ts
+++ b/config/session.ts
@@ -1,6 +1,7 @@
 import env from '#start/env'
 import app from '@adonisjs/core/services/app'
 import { defineConfig, stores } from '@adonisjs/session'
+import { defaultBrand } from '#services/plugin_registry'
 
 const sessionConfig = defineConfig({
   /**
@@ -11,7 +12,7 @@ const sessionConfig = defineConfig({
   /**
    * Cookie name storing the session identifier.
    */
-  cookieName: 'eurosky-portal-session',
+  cookieName: `${defaultBrand.nameShort.toLowerCase()}-portal-session`,
 
   /**
    * When set to true, the session id cookie will be deleted

--- a/inertia/app.tsx
+++ b/inertia/app.tsx
@@ -10,10 +10,21 @@ import { resolvePageComponent } from '@adonisjs/inertia/helpers'
 
 import.meta.glob(['../resources/images/og-image.png', './images/**'])
 
-const appName = import.meta.env.VITE_APP_NAME || 'Eurosky Portal'
+const fallbackPortalName = import.meta.env.VITE_APP_NAME || 'Portal'
+
+function getPortalName() {
+  if (typeof document !== 'undefined') {
+    return document.documentElement.dataset.portalName || fallbackPortalName
+  }
+
+  return fallbackPortalName
+}
 
 createInertiaApp({
-  title: (title) => (title ? `${title} - ${appName}` : appName),
+  title: (title) => {
+    const appName = getPortalName()
+    return title ? `${title} - ${appName}` : appName
+  },
   resolve: (name) => {
     return resolvePageComponent(
       `./pages/${name}.tsx`,

--- a/inertia/components/BetaWarning.tsx
+++ b/inertia/components/BetaWarning.tsx
@@ -1,11 +1,17 @@
-const feedbackUrl = 'https://userinput.app/#/s/did:plc:ooensn4mr5mhznzypvxelfa3/3mr5gmbhteg2p'
+import { usePage } from '@inertiajs/react'
 
 export default function BetaWarning() {
+  const {
+    props: { brand },
+  } = usePage()
+
+  if (!brand.feedbackUrl) return null
+
   return (
     <div className="bg-brand py-2 px-3 text-center text-black/80 font-semibold">
-      Eurosky Portal is currently in beta.{' '}
+      {brand.name} Portal is currently in beta.{' '}
       <a
-        href={feedbackUrl}
+        href={brand.feedbackUrl}
         rel="noopener noreferrer"
         target="_blank"
         className="underline hover:text-black/60"

--- a/inertia/components/Hero.tsx
+++ b/inertia/components/Hero.tsx
@@ -1,8 +1,13 @@
 import { Container } from '~/lib/container'
 import { Button } from '~/lib/button'
 import { LockClosedIcon } from '@heroicons/react/24/solid'
+import { usePage } from '@inertiajs/react'
 
 export function Hero() {
+  const {
+    props: { brand },
+  } = usePage()
+
   return (
     <div className="bg-neutral-50 dark:bg-slate-800">
       <Container className="pt-6 md:pt-10 pb-12 mb-6 text-center lg:pt-24">
@@ -17,7 +22,8 @@ export function Hero() {
         </div>
 
         <h1 className="mx-auto max-w-4xl font-display text-3xl sm:text-6xl lg:text-5xl leading-[1.3] font-extrabold tracking-tight text-slate-900 dark:text-slate-200">
-          Eurosky: Your Portal to <div className="text-brand">the Atmosphere.</div>
+          {brand.name}: {brand.taglineLead}
+          <div className="text-brand">the Atmosphere.</div>
         </h1>
         <p className="mx-auto mt-6 max-w-2xl text-lg text-gray-500 dark:text-slate-400 font-bold">
           One account. Dozens of apps. No lock-in.

--- a/inertia/components/Logo.tsx
+++ b/inertia/components/Logo.tsx
@@ -1,7 +1,13 @@
+import { usePage } from '@inertiajs/react'
+
 export function Logo(_props: React.ComponentProps<'div'>) {
+  const {
+    props: { brand },
+  } = usePage()
+
   return (
     <h1 id="logo">
-      <span className="invisible">Eurosky</span>
+      <span className="invisible">{brand.name}</span>
     </h1>
   )
 }

--- a/inertia/components/layouts/authenticated.tsx
+++ b/inertia/components/layouts/authenticated.tsx
@@ -32,7 +32,7 @@ import BetaWarning from '~/components/BetaWarning'
 
 export function AuthenticatedLayout(props: { children: ReactElement<Data.SharedProps> }) {
   const {
-    props: { authorizationServer },
+    props: { authorizationServer, brand },
     url,
   } = usePage()
   const user = useAuth()
@@ -80,7 +80,7 @@ export function AuthenticatedLayout(props: { children: ReactElement<Data.SharedP
                 </SidebarSection>
                 <SidebarHeading className="mt-10 font-bold">Support</SidebarHeading>
                 <SidebarSection>
-                  <SidebarItem href="https://eurosky.tech/help/" target="_blank" as={'a'}>
+                  <SidebarItem href={brand.helpUrl} target="_blank" as={'a'}>
                     <LifebuoyIcon />
                     <SidebarLabel>Help</SidebarLabel>
                   </SidebarItem>
@@ -88,7 +88,7 @@ export function AuthenticatedLayout(props: { children: ReactElement<Data.SharedP
                     <QuestionMarkCircleIcon />
                     <SidebarLabel>FAQ</SidebarLabel>
                   </SidebarItem>
-                  <SidebarItem href="https://eurosky.tech/contact/" target="_blank" as={'a'}>
+                  <SidebarItem href={brand.contactUrl} target="_blank" as={'a'}>
                     <ChatBubbleOvalLeftEllipsisIcon />
                     <SidebarLabel>Contact Us</SidebarLabel>
                   </SidebarItem>

--- a/inertia/pages/apps/show.tsx
+++ b/inertia/pages/apps/show.tsx
@@ -4,7 +4,7 @@ import { Apps } from '~/components/Apps'
 import Card from '~/lib/card'
 import { InertiaProps } from '~/types'
 
-export default function ApplicationsPage({ sections }: InertiaProps<Data.Apps>) {
+export default function ApplicationsPage({ sections, brand }: InertiaProps<Data.Apps>) {
   return (
     <Card className="p-6 sm:p-8">
       <Head title="Applications" />
@@ -12,7 +12,7 @@ export default function ApplicationsPage({ sections }: InertiaProps<Data.Apps>) 
         Applications
       </h2>
       <p className="mb-4 text-sm/6 text-gray-500 dark:text-gray-300">
-        Browse featured apps that work with your Eurosky account.
+        Browse featured apps that work with your {brand.name} account.
       </p>
       <Apps sections={sections} />
     </Card>

--- a/inertia/pages/create-account.tsx
+++ b/inertia/pages/create-account.tsx
@@ -13,24 +13,26 @@ export default function CreateAccount(
     legalDocuments: Data.LegalDocuments
   }>
 ) {
-  const { props: pageProps } = usePage()
+  const {
+    props: { brand, flash },
+  } = usePage()
   return (
     <div className="bg-neutral-50 dark:bg-slate-900 min-h-dvh-minus-35">
       <Head title="Create account" />
       <Container className="py-10 md:pt-24">
-        {pageProps.flash.error && (
+        {flash.error && (
           <Card className="w-full md:w-3/4 lg:w-1/2 m-auto px-4 py-2 mb-8 bg-gray-500! dark:bg-slate-600! text-white!">
             <div className="flex flex-row gap-2 items-center-safe">
               <div className="h-8 w-8">
                 <ExclamationTriangleIcon color="white" />
               </div>
-              <span>{pageProps.flash.error}</span>
+              <span>{flash.error}</span>
             </div>
           </Card>
         )}
         <Card className="my-10 w-full md:w-3/4 lg:w-1/2 m-auto p-4">
           <h1 className="mx-auto max-w-4xl mb-2 text-center font-display text-3xl leading-[1.2] font-extrabold tracking-tight text-slate-900 dark:text-slate-200 sm:text-5xl">
-            Create Your <div className="text-brand">Eurosky Account.</div>
+            Create Your <div className="text-brand">{brand.name} Account.</div>
           </h1>
           <Text className="text-center text-slate-600">
             Before we get started, please review and accept our terms.

--- a/inertia/pages/dashboard/show.tsx
+++ b/inertia/pages/dashboard/show.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from 'react'
-import { router as inertiaRouter } from '@inertiajs/react'
+import { router as inertiaRouter, usePage } from '@inertiajs/react'
 import type { ActivityRow, GetRecordsResult } from '#services/activity_service'
 import { ActivityList } from '~/components/ActivityList'
 import { UserAvatar } from '~/components/UserAvatar'
@@ -30,6 +30,9 @@ export default function Dashboard({
 }>) {
   const user = useAuth()
   const router = useRouter()
+  const {
+    props: { brand },
+  } = usePage()
   const isHandleInvalid = user.handle === INVALID_HANDLE
 
   const dismissWelcome = useCallback(async () => {
@@ -59,7 +62,7 @@ export default function Dashboard({
             <Text className="text-white! text-shadow-sm text-shadow-amber-600/80">
               It looks like you've attempted to change your handle, and we can't verify it.{' '}
               <a
-                href="https://eurosky.tech/help/#handle-invalid"
+                href={`${brand.helpUrl}#handle-invalid`}
                 target="_blank"
                 className="font-semibold hover:underline"
               >
@@ -76,8 +79,8 @@ export default function Dashboard({
               Welcome to the Atmosphere
             </h2>
             <p className="mt-0.5 text-xs/6 text-gray-500 dark:text-gray-300">
-              Eurosky is your European home on the Atmosphere &ndash; a global network of social
-              apps and services.
+              {brand.name} is your{brand.homeDescriptor ? ` ${brand.homeDescriptor}` : ''} home on
+              the Atmosphere &ndash; a global network of social apps and services.
             </p>
             {!isHandleInvalid && (
               <p className="mt-0.5 text-xs/6 text-gray-500 dark:text-gray-300">
@@ -148,8 +151,8 @@ export default function Dashboard({
             Explore the ecosystem
           </h2>
           <p className="text-xs/6 text-gray-500 dark:text-gray-300">
-            Your Eurosky account works with dozens of apps. Browse the featured apps below and click
-            one to get started.
+            Your {brand.name} account works with dozens of apps. Browse the featured apps below and
+            click one to get started.
           </p>
           <Button
             route="explore.learn_more"
@@ -192,7 +195,7 @@ export default function Dashboard({
           Featured applications
         </h2>
         <p className="text-base text-neutral-400 dark:text-slate-400 mb-6">
-          Your Eurosky account works with all of these.
+          Your {brand.name} account works with all of these.
         </p>
 
         <AppGrid apps={apps} />

--- a/inertia/pages/faq/show.tsx
+++ b/inertia/pages/faq/show.tsx
@@ -15,7 +15,9 @@ export default function Faq(props: InertiaProps<{ faq: { question: string; answe
       </Container>
       <div className="bg-neutral-50 dark:bg-slate-800 min-h-dvh-minus-35">
         <Container className="pt-5 pb-10 md:pb-24 md:pt-12 faq">
-          <h2 className="text-2xl font-semibold text-ink dark:text-white mb-8">Eurosky Portal</h2>
+          <h2 className="text-2xl font-semibold text-ink dark:text-white mb-8">
+            {props.brand.name} Portal
+          </h2>
           {props.faq.map((entry, idx) => (
             <details
               key={idx}

--- a/inertia/pages/login.tsx
+++ b/inertia/pages/login.tsx
@@ -11,24 +11,26 @@ import { Head, usePage } from '@inertiajs/react'
 import { ExclamationTriangleIcon } from '@heroicons/react/24/solid'
 
 export default function Login({ migrationUrl }: InertiaProps<{ migrationUrl?: string }>) {
-  const { props: pageProps } = usePage()
+  const {
+    props: { brand, flash, handleDomain },
+  } = usePage()
   return (
     <div className="bg-neutral-50 dark:bg-slate-900 min-h-dvh-minus-35">
       <Head title="Sign in" />
       <Container className="pt-10 md:pt-24">
-        {pageProps.flash.error && (
+        {flash.error && (
           <Card className="w-full md:w-3/4 lg:w-1/2 m-auto px-4 py-2 mb-8 bg-gray-500! dark:bg-slate-600! text-white!">
             <div className="flex flex-row gap-2 items-center-safe">
               <div className="h-8 w-8">
                 <ExclamationTriangleIcon color="white" />
               </div>
-              <span>{pageProps.flash.error}</span>
+              <span>{flash.error}</span>
             </div>
           </Card>
         )}
         <Card className="w-full md:w-3/4 lg:w-1/2 m-auto p-4 mb-8">
           <h1 className="mx-auto max-w-4xl mb-2 text-center font-display text-3xl leading-[1.2] font-extrabold tracking-tight text-slate-900 dark:text-slate-200 sm:text-5xl">
-            Sign Into Your <div className="text-brand">Eurosky Account.</div>
+            Sign Into Your <div className="text-brand">{brand.name} Account.</div>
           </h1>
           <Text className="text-center">Enter your handle below to login to your account</Text>
           <Form className="my-6" route="oauth.login">
@@ -40,7 +42,7 @@ export default function Login({ migrationUrl }: InertiaProps<{ migrationUrl?: st
                     id="input"
                     name="input"
                     type="input"
-                    placeholder="sebastian.eurosky.social"
+                    placeholder={handleDomain ? `username${handleDomain}` : 'username.example.com'}
                     defaultValue={errors.old_input ?? ''}
                     required
                     autoCapitalize="false"

--- a/inertia/pages/onboarding.tsx
+++ b/inertia/pages/onboarding.tsx
@@ -8,6 +8,7 @@ import Notice from '~/lib/notice'
 import { Form } from '@adonisjs/inertia/react'
 import { Button } from '~/lib/button'
 import { Text } from '~/lib/text'
+import { usePage } from '@inertiajs/react'
 
 export default function Onboarding(
   props: InertiaProps<{
@@ -16,15 +17,19 @@ export default function Onboarding(
     legalDocuments: Data.LegalDocuments
   }>
 ) {
+  const {
+    props: { brand },
+  } = usePage()
+
   return (
     <div className="bg-neutral-50 dark:bg-slate-900 min-h-dvh-minus-35">
       <Head title="Accept terms & conditions" />
       <Container className="pt-10 md:pt-24">
         <Card className="w-full md:w-1/2 m-auto p-4 mb-6">
           <h1 className="mx-auto max-w-4xl mb-2 text-center font-display text-3xl leading-[1.2] font-extrabold tracking-tight text-slate-900 dark:text-slate-200 sm:text-5xl">
-            Welcome to <div className="text-brand">Eurosky.</div>
+            Welcome to <div className="text-brand">{brand.name}.</div>
           </h1>
-          {renderNotice(props.termsUpdated, props.privacyUpdated)}
+          {renderNotice(props.termsUpdated, props.privacyUpdated, brand.name)}
           <PolicyForm
             route="account.store_acceptance"
             terms={props.legalDocuments.terms}
@@ -38,7 +43,7 @@ export default function Onboarding(
                   Logout
                 </Button>
               </Form>{' '}
-              and not use Eurosky Portal.
+              and not use {brand.name} Portal.
             </Text>
           )}
         </Card>
@@ -47,7 +52,7 @@ export default function Onboarding(
   )
 }
 
-function renderNotice(termsUpdated: boolean, privacyUpdated: boolean) {
+function renderNotice(termsUpdated: boolean, privacyUpdated: boolean, brandName: string) {
   if (!termsUpdated && !privacyUpdated) {
     return
   }
@@ -60,5 +65,10 @@ function renderNotice(termsUpdated: boolean, privacyUpdated: boolean) {
     title = `Our Privacy Policy has been updated`
   }
 
-  return <Notice title={title} text="Please accept the changes to continue using Eurosky Portal" />
+  return (
+    <Notice
+      title={title}
+      text={`Please accept the changes to continue using ${brandName} Portal`}
+    />
+  )
 }

--- a/inertia/ssr.tsx
+++ b/inertia/ssr.tsx
@@ -7,9 +7,11 @@ import { createInertiaApp } from '@inertiajs/react'
 import { TuyauProvider } from '@adonisjs/inertia/react'
 import { resolvePageComponent } from '@adonisjs/inertia/helpers'
 
-const appName = import.meta.env.VITE_APP_NAME || 'Eurosky Portal'
-
 export default function render(page: any) {
+  const appName = page.props.brand
+    ? `${page.props.brand.name} Portal`
+    : import.meta.env.VITE_APP_NAME || 'Portal'
+
   return createInertiaApp({
     title: (title) => (title ? `${title} - ${appName}` : appName),
     page,

--- a/providers/plugin_registry_provider.ts
+++ b/providers/plugin_registry_provider.ts
@@ -1,0 +1,10 @@
+import type { ApplicationService } from '@adonisjs/core/types'
+import PluginRegistry from '#services/plugin_registry'
+
+export default class PluginRegistryProvider {
+  constructor(protected app: ApplicationService) {}
+
+  register() {
+    this.app.container.singleton(PluginRegistry, () => new PluginRegistry())
+  }
+}

--- a/resources/views/inertia_layout.edge
+++ b/resources/views/inertia_layout.edge
@@ -1,8 +1,8 @@
-@let(title = "Eurosky Portal")
-@let(description = "Your Portal to the Atmosphere")
+@let(title = portal_brand.name + " Portal")
+@let(description = portal_brand.taglineLead + " the Atmosphere")
 
 <!DOCTYPE html>
-<html>
+<html data-portal-name="{{ title }}">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -30,7 +30,7 @@
     <!-- Facebook Meta Tags -->
     <meta property="og:url" content="{{ opengraph_url() }}" />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Eurosky Portal" />
+    <meta property="og:title" content="{{ title }}" />
     <meta property="og:description" content="{{ description }}" />
     <meta property="og:image" content="{{ opengraph_url(asset('resources/images/og-image.png')) }}" />
     <meta property="og:image:height" content="630" />
@@ -40,7 +40,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta property="twitter:domain" content="{{ service_domain }}" />
     <meta property="twitter:url" content="{{ opengraph_url() }}" />
-    <meta name="twitter:title" content="Eurosky Portal" />
+    <meta name="twitter:title" content="{{ title }}" />
     <meta name="twitter:description" content="{{ description }}" />
     <meta name="twitter:image" content="{{ opengraph_url(asset('resources/images/og-image.png')) }}" />
 

--- a/start/view.ts
+++ b/start/view.ts
@@ -1,8 +1,17 @@
 import edge from 'edge.js'
+import app from '@adonisjs/core/services/app'
 import { edgeMarkdown } from 'edge-markdown'
+import { defaultBrand } from '#services/plugin_registry'
+import PluginRegistry from '#services/plugin_registry'
 import { appHost, toAbsoluteUrl } from '#services/url_service'
 
 edge.use(edgeMarkdown, {})
 
 edge.global('opengraph_url', toAbsoluteUrl)
 edge.global('service_domain', appHost)
+edge.global('portal_brand', { ...defaultBrand })
+
+app.booted(async () => {
+  const pluginRegistry = await app.container.make(PluginRegistry)
+  edge.global('portal_brand', { ...pluginRegistry.brand })
+})

--- a/tests/unit/plugin_registry.spec.ts
+++ b/tests/unit/plugin_registry.spec.ts
@@ -1,0 +1,66 @@
+import { test } from '@japa/runner'
+import PluginRegistry, { defaultBrand } from '#services/plugin_registry'
+
+test.group('PluginRegistry', () => {
+  test('uses the default brand when no plugin is registered', ({ assert }) => {
+    const registry = new PluginRegistry()
+
+    assert.deepEqual(registry.brand, defaultBrand)
+  })
+
+  test('overrides the default brand with a plugin brand', ({ assert }) => {
+    const registry = new PluginRegistry()
+
+    registry.register({
+      id: 'example',
+      brand: {
+        name: 'Example Co.',
+        nameShort: 'Example',
+        tagline: 'A portal for example',
+        helpUrl: 'https://example.com/help',
+        contactUrl: 'https://example.com/contact',
+      },
+    })
+
+    assert.deepEqual(registry.brand, {
+      ...defaultBrand,
+      name: 'Example Co.',
+      nameShort: 'Example',
+      tagline: 'A portal for example',
+      helpUrl: 'https://example.com/help',
+      contactUrl: 'https://example.com/contact',
+    })
+  })
+
+  test('preserves defaults for unspecified brand values', ({ assert }) => {
+    const registry = new PluginRegistry()
+
+    registry.register({
+      id: 'example',
+      brand: { name: 'Example Co.' },
+    })
+
+    assert.equal(registry.brand.name, 'Example Co.')
+    assert.equal(registry.brand.tagline, defaultBrand.tagline)
+    assert.equal(registry.brand.helpUrl, defaultBrand.helpUrl)
+  })
+
+  test('lets later plugins override earlier brand values', ({ assert }) => {
+    const registry = new PluginRegistry()
+
+    registry.register({ id: 'first', brand: { name: 'First' } })
+    registry.register({ id: 'second', brand: { name: 'Second' } })
+
+    assert.equal(registry.brand.name, 'Second')
+  })
+
+  test('returns a copy of the registered plugins', ({ assert }) => {
+    const registry = new PluginRegistry()
+    registry.register({ id: 'example' })
+
+    const plugins = registry.plugins as Array<{ id: string }>
+    plugins.length = 0
+
+    assert.lengthOf(registry.plugins, 1)
+  })
+})

--- a/tests/unit/plugin_registry.spec.ts
+++ b/tests/unit/plugin_registry.spec.ts
@@ -16,7 +16,7 @@ test.group('PluginRegistry', () => {
       brand: {
         name: 'Example Co.',
         nameShort: 'Example',
-        tagline: 'A portal for example',
+        taglineLead: 'A portal for',
         helpUrl: 'https://example.com/help',
         contactUrl: 'https://example.com/contact',
       },
@@ -26,7 +26,7 @@ test.group('PluginRegistry', () => {
       ...defaultBrand,
       name: 'Example Co.',
       nameShort: 'Example',
-      tagline: 'A portal for example',
+      taglineLead: 'A portal for',
       helpUrl: 'https://example.com/help',
       contactUrl: 'https://example.com/contact',
     })
@@ -41,7 +41,7 @@ test.group('PluginRegistry', () => {
     })
 
     assert.equal(registry.brand.name, 'Example Co.')
-    assert.equal(registry.brand.tagline, defaultBrand.tagline)
+    assert.equal(registry.brand.taglineLead, defaultBrand.taglineLead)
     assert.equal(registry.brand.helpUrl, defaultBrand.helpUrl)
   })
 


### PR DESCRIPTION
Adds the first plugin extension point, starting with moving runtime brand identity behind the plugin system.

- register plugins through an AdonisJS provider and registry
- share brand identity through Inertia and Edge
- migrate portal copy, links, metadata, and OAuth messages
- retains Eurosky as the default brand

Checks: `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm build`

Future work will migrate external services, deployment identities, and component overrides.